### PR TITLE
Fix uninitialized EDC bytes for Mode 2 Form 2 NoCrc sectors

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1728,6 +1728,8 @@ AARU_EXPORT int32_t AARU_CALL aaruf_read_sector_long(void *context, const uint64
                             memcpy(data + 24, bare_data, 2324);
                             if(suffix_status == SectorStatusMode2Form2Ok)
                                 aaruf_ecc_cd_reconstruct(ctx->ecc_cd_context, data, kTrackTypeCdMode2Form2);
+                            else
+                                memset(data + 2348, 0, 4);
                         }
                         else if(suffix_status == SectorStatusNotDumped)
                             res = AARUF_STATUS_SECTOR_NOT_DUMPED;
@@ -1750,6 +1752,8 @@ AARU_EXPORT int32_t AARU_CALL aaruf_read_sector_long(void *context, const uint64
                             memcpy(data + 24, bare_data, 2324);
                             if((ctx->sector_suffix_ddt[corrected_sector_address] & CD_XFIX_MASK) == Mode2Form2Ok)
                                 aaruf_ecc_cd_reconstruct(ctx->ecc_cd_context, data, kTrackTypeCdMode2Form2);
+                            else
+                                memset(data + 2348, 0, 4);
                         }
                         else if((ctx->sector_suffix_ddt[corrected_sector_address] & CD_XFIX_MASK) == NotDumped)
                             res = AARUF_STATUS_SECTOR_NOT_DUMPED;


### PR DESCRIPTION
When reading back Mode 2 Form 2 sectors with SectorStatusMode2Form2NoCrc, the 4-byte EDC field at bytes 2348-2351 was left untouched. Since the caller's buffer may contain arbitrary data, this results in non-deterministic output for those bytes.

The NoCrc status indicates the original disc had no CRC (zeroed EDC). The fix adds the missing else branch to zero the EDC field, matching the behavior that Mode2Form2Ok already has via aaruf_ecc_cd_reconstruct.

Both DDT v1 and v2 code paths are fixed, which fixes PS1 roundtrip from raw images for me.