### PR TITLE
Reserve compression ID 4 for Zstandard (zstd)

### DIFF
--- a/include/aaruformat/enums.h
+++ b/include/aaruformat/enums.h
@@ -33,7 +33,9 @@ typedef enum
     kCompressionNone    = 0,  ///< Not compressed.
     kCompressionLzma    = 1,  ///< LZMA compression.
     kCompressionFlac    = 2,  ///< FLAC compression.
-    kCompressionLzmaCst = 3   ///< LZMA applied to Claunia Subchannel Transform processed data.
+    kCompressionLzmaCst = 3,  ///< LZMA applied to Claunia Subchannel Transform processed data.
+    kCompressionZstd    = 4,  ///< Zstandard compression (reserved for future implementation).
+    kCompressionZstdCst = 5   ///< Zstandard applied to Claunia Subchannel Transform processed data (reserved).
 } CompressionType;
 
 /**


### PR DESCRIPTION
Adds kCompressionZstd = 4 to the CompressionType enum as a reserved value for future Zstandard compression support.

Ref: https://github.com/aaru-dps/libaaruformat/issues/5

Even when not implemented, we would appreciate the reservation of that number. Hopefully this request is not to harsh. For reasons I mentioned in the issue, we implemented fully zstandard in our fork, since that allows to load all images in less than 4 seconds in to memory compared with about 30s for lzma.