### PR TITLE
Fix calling convention placement for pointer-returning functions

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -276,7 +276,7 @@ static void cleanup_failed_create(aaruformat_context *ctx)
  * @see aaruf_set_tape_file() for defining tape file metadata
  * @see aaruf_set_tape_partition() for defining tape partition metadata
  */
-AARU_EXPORT void AARU_CALL *aaruf_create(const char *filepath, const uint32_t media_type, const uint32_t sector_size,
+AARU_EXPORT void *AARU_CALL aaruf_create(const char *filepath, const uint32_t media_type, const uint32_t sector_size,
                                          const uint64_t user_sectors, const uint64_t negative_sectors,
                                          const uint64_t overflow_sectors, const char *options,
                                          const uint8_t *application_name, const uint8_t application_name_length,

--- a/src/open.c
+++ b/src/open.c
@@ -220,7 +220,7 @@ static void cleanup_open_failure(aaruformat_context *ctx)
  * @see aaruf_write_sector() for writing sectors in resume mode
  * @see aaruf_identify() for identifying image type before opening
  */
-AARU_EXPORT void AARU_CALL *aaruf_open(const char *filepath, const bool resume_mode,
+AARU_EXPORT void *AARU_CALL aaruf_open(const char *filepath, const bool resume_mode,
                                        const char *options)  // NOLINT(readability-function-size)
 {
     aaruformat_context *ctx           = NULL;


### PR DESCRIPTION
`aaruf_open()` and `aaruf_create() `implementations use `void AARU_CALL *` while _decls.h_ declares them as `void *AARU_CALL`. On non-Windows this is harmless  (`AARU_CALL` is empty), but with __stdcall the placement is ambiguous. Matches implementation to declaration and to the existing pattern in  `aaruf_ecc_cd_init()`.

This may be cosmetic on current compilers — feel free to close if you consider it unnecessary.