### PR TITLE
Add long sector for Wii/GC

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1482,6 +1482,72 @@ AARU_EXPORT int32_t AARU_CALL aaruf_read_sector_long(void *context, const uint64
                 return AARUF_STATUS_OK;
             }
 
+            if(ctx->image_info.MediaType == GOD || ctx->image_info.MediaType == WOD)
+             {
+                 if(ctx->sector_id == NULL || ctx->sector_ied == NULL || ctx->sector_cpr_mai == NULL ||
+                    ctx->sector_edc == NULL)
+                     return aaruf_read_sector(context, sector_address, negative, data, length, sector_status);
+ 
+                 if(*length < 2064 || data == NULL)
+                 {
+                     *length = 2064;
+                     FATAL("Buffer too small for sector, required %u bytes", *length);
+ 
+                     TRACE("Exiting aaruf_read_sector_long() = AARUF_ERROR_BUFFER_TOO_SMALL");
+                     return AARUF_ERROR_BUFFER_TOO_SMALL;
+                 }
+ 
+                 bare_length  = 0;
+                 query_status = aaruf_read_sector(context, sector_address, negative, NULL, &bare_length, sector_status);
+ 
+                 if(query_status != AARUF_ERROR_BUFFER_TOO_SMALL && query_status != AARUF_STATUS_OK)
+                 {
+                     TRACE("Exiting aaruf_read_sector_long() = %d", query_status);
+                     return query_status;
+                 }
+ 
+                 if(bare_length == 0)
+                 {
+                     FATAL("Invalid bare sector length (0)");
+ 
+                     TRACE("Exiting aaruf_read_sector_long() = AARUF_ERROR_INCORRECT_DATA_SIZE");
+                     return AARUF_ERROR_INCORRECT_DATA_SIZE;
+                 }
+ 
+                 TRACE("Allocating memory for bare data");
+                 bare_data = (uint8_t *)malloc(bare_length);
+ 
+                 if(bare_data == NULL)
+                 {
+                     FATAL("Could not allocate memory for bare data");
+ 
+                     TRACE("Exiting aaruf_read_sector_long() = AARUF_ERROR_NOT_ENOUGH_MEMORY");
+                     return AARUF_ERROR_NOT_ENOUGH_MEMORY;
+                 }
+ 
+                 res = aaruf_read_sector(context, sector_address, negative, bare_data, &bare_length, sector_status);
+ 
+                 if(res != AARUF_STATUS_OK)
+                 {
+                     *length = 2064;
+                     free(bare_data);
+ 
+                     TRACE("Exiting aaruf_read_sector_long() = %d", res);
+                     return res;
+                 }
+ 
+                 memcpy(data, ctx->sector_id + corrected_sector_address * 4, 4);
+                 memcpy(data + 4, ctx->sector_ied + corrected_sector_address * 2, 2);
+                 memcpy(data + 6, bare_data, 2048);
+                 memcpy(data + 2054, ctx->sector_cpr_mai + corrected_sector_address * 6, 6);
+                 memcpy(data + 2060, ctx->sector_edc + corrected_sector_address * 4, 4);
+ 
+                 *length = 2064;
+ 
+                 free(bare_data);
+                 return AARUF_STATUS_OK;
+             }
+
             if(*length < 2352 || data == NULL)
             {
                 *length = 2352;

--- a/src/write.c
+++ b/src/write.c
@@ -719,6 +719,22 @@ AARU_EXPORT int32_t AARU_CALL aaruf_write_sector_long(void *context, uint64_t se
                 return aaruf_write_sector(context, sector_address, negative, data + 12, sector_status, 2048);
             }
 
+            // Nintendo DVD long sector
+            if(length == 2064 && ctx->image_info.MediaType == GOD || ctx->image_info.MediaType == WOD)
+            {
+                if(ctx->sector_id == NULL) ctx->sector_id = calloc(1, 4 * total_sectors);
+                if(ctx->sector_ied == NULL) ctx->sector_ied = calloc(1, 2 * total_sectors);
+                if(ctx->sector_cpr_mai == NULL) ctx->sector_cpr_mai = calloc(1, 6 * total_sectors);
+                if(ctx->sector_edc == NULL) ctx->sector_edc = calloc(1, 4 * total_sectors);
+
+                memcpy(ctx->sector_id + corrected_sector_address * 4, data, 4);
+                memcpy(ctx->sector_ied + corrected_sector_address * 2, data + 4, 2);
+                memcpy(ctx->sector_cpr_mai + corrected_sector_address * 6, data + 2054, 6);
+                memcpy(ctx->sector_edc + corrected_sector_address * 4, data + 2060, 4);
+    
+                return aaruf_write_sector(context, sector_address, negative, data + 6, sector_status, 2048);
+            }
+
             if(length != 2352)
             {
                 FATAL("Incorrect sector size");


### PR DESCRIPTION
Nintendo DVDs have a different layout than regular DVDs. This should make libaaruformat handle the long sectors of them.