### PR TITLE
Add multi-threaded zstd compression support

### DIFF
--- a/3rdparty/zstd.cmake
+++ b/3rdparty/zstd.cmake
@@ -45,7 +45,14 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
 endif()
 
 target_include_directories(zstd_static PUBLIC ${ZSTD_LIB_DIR})
+target_compile_definitions(zstd_static PRIVATE ZSTD_MULTITHREAD)
 set_property(TARGET zstd_static PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+
+# zstd multi-threading requires pthreads on POSIX (musl includes pthreads in libc)
+if(NOT WIN32)
+  find_package(Threads REQUIRED)
+  target_link_libraries(zstd_static PRIVATE Threads::Threads)
+endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
   if(MSVC)

--- a/include/aaruformat/context.h
+++ b/include/aaruformat/context.h
@@ -303,6 +303,7 @@ typedef struct aaruformat_context
     bool     compression_enabled;  ///< True if block compression enabled (writing path).
     bool     use_zstd;             ///< Use Zstandard instead of LZMA for data blocks.
     int      zstd_level;           ///< Zstandard compression level (writing path, default 19).
+    int      num_threads;          ///< Compression worker threads (1 = single-threaded, default).
 
     /* Tape-specific structures */
     tapeFileHashEntry      *tape_files;       ///< Hash table root for tape files

--- a/include/aaruformat/decls.h
+++ b/include/aaruformat/decls.h
@@ -257,7 +257,7 @@ AARU_EXPORT int32_t AARU_CALL aaruf_lzma_encode_buffer(uint8_t *dst_buffer, size
 AARU_EXPORT size_t AARU_CALL aaruf_zstd_decode_buffer(uint8_t *dst_buffer, size_t dst_size, const uint8_t *src_buffer,
                                                        size_t src_size);
 AARU_EXPORT size_t AARU_CALL aaruf_zstd_encode_buffer(uint8_t *dst_buffer, size_t dst_size, const uint8_t *src_buffer,
-                                                       size_t src_size, int level);
+                                                       size_t src_size, int level, int num_threads);
 
 AARU_EXPORT void AARU_CALL aaruf_md5_init(md5_ctx *ctx);
 AARU_EXPORT void AARU_CALL aaruf_md5_update(md5_ctx *ctx, const void *data, unsigned long size);

--- a/include/aaruformat/structs/options.h
+++ b/include/aaruformat/structs/options.h
@@ -41,6 +41,9 @@
  *    sha256=true|false            Generate SHA-256 checksum.
  *    blake3=true|false            Generate BLAKE3 checksum (may require build-time support; ignored if unsupported).
  *    spamsum=true|false           Generate SpamSum fuzzy hash.
+ *    zstd=true|false              Use Zstandard instead of LZMA for data blocks.
+ *    zstd_level=<n>               Zstandard compression level (1-22).
+ *    threads=<n>                  Compression worker threads (>= 1). zstd: nbWorkers; LZMA: clamped to [1, 2].
  *
  *  Defaults (when option string NULL or key omitted):
  *    compress=true, deduplicate=true, dictionary=33554432, table_shift=9, data_shift=12,
@@ -229,6 +232,9 @@ typedef struct
     bool     spamsum;          ///< Generate SpamSum fuzzy hash (ChecksumAlgorithm::SpamSum) if enabled.
     bool     zstd;             ///< Use Zstandard instead of LZMA for data blocks. Default: false.
     int      zstd_level;       ///< Zstandard compression level (1-22). Default: 19.
+    int      num_threads;      ///< Number of compression worker threads. Default: 1 (single-threaded).
+                               ///< zstd: passed as nbWorkers (0 and 1 both mean single-threaded).
+                               ///< LZMA: clamped to [1, 2] (2 = threaded match finder).
 } aaru_options;
 
 #endif  // LIBAARUFORMAT_OPTIONS_H

--- a/src/close.c
+++ b/src/close.c
@@ -1710,7 +1710,7 @@ static void write_sector_subchannel(aaruformat_context *ctx)
             if(ctx->use_zstd)
             {
                 dst_size = aaruf_zstd_encode_buffer(dst_buffer, subchannel_block.length, cst_buffer,
-                                                     subchannel_block.length, ctx->zstd_level);
+                                                     subchannel_block.length, ctx->zstd_level, ctx->num_threads);
                 if(dst_size == 0) dst_size = subchannel_block.length; /* compression failed, fall through to none */
             }
             else
@@ -1776,7 +1776,7 @@ static void write_sector_subchannel(aaruformat_context *ctx)
         if(ctx->use_zstd)
         {
             dst_size = aaruf_zstd_encode_buffer(dst_buffer, subchannel_block.length, ctx->sector_subchannel,
-                                                 subchannel_block.length, ctx->zstd_level);
+                                                 subchannel_block.length, ctx->zstd_level, ctx->num_threads);
             if(dst_size == 0) dst_size = subchannel_block.length; /* compression failed, fall through to none */
         }
         else

--- a/src/compression/zstd.c
+++ b/src/compression/zstd.c
@@ -44,17 +44,31 @@ AARU_EXPORT size_t AARU_CALL aaruf_zstd_decode_buffer(uint8_t *dst_buffer, size_
 /**
  * @brief Encodes a buffer using Zstandard compression.
  *
+ * Uses the advanced API (ZSTD_CCtx) to support multi-threaded compression
+ * when num_threads > 1. With num_threads <= 1 the output is bit-identical
+ * to the simple ZSTD_compress() API.
+ *
  * @param dst_buffer Pointer to the destination buffer.
  * @param dst_size Size of the destination buffer.
  * @param src_buffer Pointer to the source (uncompressed) buffer.
  * @param src_size Size of the source buffer.
  * @param level Compression level (1-22).
+ * @param num_threads Number of worker threads (1 = single-threaded).
  * @return Number of compressed bytes, or 0 on error.
  */
 AARU_EXPORT size_t AARU_CALL aaruf_zstd_encode_buffer(uint8_t *dst_buffer, size_t dst_size, const uint8_t *src_buffer,
-                                                       size_t src_size, int level)
+                                                       size_t src_size, int level, int num_threads)
 {
-    size_t result = ZSTD_compress(dst_buffer, dst_size, src_buffer, src_size, level);
+    ZSTD_CCtx *cctx = ZSTD_createCCtx();
+    if(cctx == NULL) return 0;
+
+    ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, level);
+
+    if(num_threads > 1) ZSTD_CCtx_setParameter(cctx, ZSTD_c_nbWorkers, num_threads);
+
+    size_t result = ZSTD_compress2(cctx, dst_buffer, dst_size, src_buffer, src_size);
+
+    ZSTD_freeCCtx(cctx);
 
     if(ZSTD_isError(result)) return 0;
 

--- a/src/create.c
+++ b/src/create.c
@@ -528,6 +528,7 @@ AARU_EXPORT void *AARU_CALL aaruf_create(const char *filepath, const uint32_t me
     ctx->deduplicate         = parsed_options.deduplicate;
     ctx->use_zstd            = parsed_options.zstd;
     ctx->zstd_level          = parsed_options.zstd_level;
+    ctx->num_threads         = parsed_options.num_threads;
     if(ctx->deduplicate)
         ctx->sector_hash_map = create_map(ctx->user_data_ddt_header.blocks * 25 / 100);  // 25% of total sectors
 

--- a/src/options.c
+++ b/src/options.c
@@ -52,16 +52,17 @@ aaru_options parse_options(const char *options, bool *table_shift_found)
                            .blake3          = false,
                            .spamsum         = false,
                            .zstd            = false,
-                           .zstd_level      = 19};
+                           .zstd_level      = 19,
+                           .num_threads     = 1};
 
     if(options == NULL)
     {
         TRACE("Exiting parse_options() = {compress: %d, deduplicate: %d, dictionary: %u, table_shift: %d, "
               "data_shift: %u, block_alignment: %u, md5: %d, sha1: %d, sha256: %d, blake3: %d, spamsum: %d, "
-              "zstd: %d, zstd_level: %d}",
+              "zstd: %d, zstd_level: %d, num_threads: %d}",
               parsed.compress, parsed.deduplicate, parsed.dictionary, parsed.table_shift, parsed.data_shift,
               parsed.block_alignment, parsed.md5, parsed.sha1, parsed.sha256, parsed.blake3, parsed.spamsum,
-              parsed.zstd, parsed.zstd_level);
+              parsed.zstd, parsed.zstd_level, parsed.num_threads);
         return parsed;
     }
 
@@ -146,15 +147,20 @@ aaru_options parse_options(const char *options, bool *table_shift_found)
             }
             else if(strncmp(key, "zstd", 4) == 0)
                 parsed.zstd = bval;
+            else if(strncmp(key, "threads", 7) == 0)
+            {
+                parsed.num_threads = (int)strtol(value, NULL, 10);
+                if(parsed.num_threads < 1) parsed.num_threads = 1;
+            }
         }
         token = strtok_r(NULL, ";", &saveptr);
     }
 
     TRACE("Exiting parse_options() = {compress: %d, deduplicate: %d, dictionary: %u, table_shift: %d, "
           "data_shift: %u, block_alignment: %u, md5: %d, sha1: %d, sha256: %d, blake3: %d, spamsum: %d, "
-          "zstd: %d, zstd_level: %d}",
+          "zstd: %d, zstd_level: %d, num_threads: %d}",
           parsed.compress, parsed.deduplicate, parsed.dictionary, parsed.table_shift, parsed.data_shift,
           parsed.block_alignment, parsed.md5, parsed.sha1, parsed.sha256, parsed.blake3, parsed.spamsum,
-          parsed.zstd, parsed.zstd_level);
+          parsed.zstd, parsed.zstd_level, parsed.num_threads);
     return parsed;
 }

--- a/src/write.c
+++ b/src/write.c
@@ -1603,7 +1603,7 @@ int32_t aaruf_close_current_block(aaruformat_context *ctx)
 
             size_t zstd_dst_size =
                 aaruf_zstd_encode_buffer(cmp_buffer, ctx->current_block_header.length * 2, ctx->writing_buffer,
-                                         ctx->current_block_header.length, ctx->zstd_level);
+                                         ctx->current_block_header.length, ctx->zstd_level, ctx->num_threads);
 
             if(zstd_dst_size == 0)
             {


### PR DESCRIPTION
Switch zstd encoder from simple API (ZSTD_compress) to advanced API (ZSTD_CCtx + ZSTD_compress2) with configurable worker threads via ZSTD_c_nbWorkers. Consumer controls threading through threads=N option string parameter. Default is 1 (single-threaded, bit-identical output to previous behavior).

- Enable ZSTD_MULTITHREAD compile definition and link pthreads
- Add num_threads field to options struct and context
- Parse threads=N in option string (clamped >= 1)
- Rewrite aaruf_zstd_encode_buffer() with num_threads parameter
- Update all call sites (write.c, close.c)