### PR TITLE
Fix/spec ddt2 alignment formula

### DIFF
--- a/docs/spec/blocks/ddt2.adoc
+++ b/docs/spec/blocks/ddt2.adoc
@@ -141,7 +141,7 @@ These parameters are stored in both the master header and each deduplication tab
 
 ===== Block Alignment
 
-Each block in the image is aligned to a boundary of `2 << block_alignment_shift`.
+Each block in the image is aligned to a boundary of `1 << block_alignment_shift`.
 This alignment is essential for technical consistency and performance.
 
 ===== Table Shift
@@ -157,10 +157,10 @@ For example:
 | Sectors per Entry
 
 | 1
-| (2 << table_shift)^2 = 262144
+| (1 << table_shift)^2 = 262144
 
 | 2
-| 2 << table_shift = 512
+| 1 << table_shift = 512
 
 | 3
 | 1
@@ -175,7 +175,7 @@ In non-terminal levels (i.e., all except the last), each entry contains:
 - Relevant metadata flags for its sector range
 - An offset pointing to the next deduplication level
 
-To obtain the byte offset in the image file, multiply this offset by `2 << block_alignment_shift`.
+To obtain the byte offset in the image file, multiply this offset by `1 << block_alignment_shift`.
 
 In the last level, the `data_shift` is applied as follows to determine the specific item within a data block:
 
@@ -191,13 +191,13 @@ Step 1: Mask and shift
 0x35006 >> 5 = 0x1A80
 
 Step 2: Compute byte offset
-0x1A80 * (2 << 9) = 0x6A0000
+0x1A80 * (1 << 9) = 0x350000
 
 Step 3: Determine item index
 0x35006 & 0x1F = 6
 
 Result:
-Sector is stored at byte offset 0x6A0000 as item number 6 in the data block.
+Sector is stored at byte offset 0x350000 as item number 6 in the data block.
 ----
 
 ===== Deduplication Table Status

--- a/docs/spec/blocks/header.adoc
+++ b/docs/spec/blocks/header.adoc
@@ -53,9 +53,9 @@ A bump indicates potential breaking changes.
 | guid | uint8_t[GUID_SIZE] | Globally Unique Identifier (GUID) that allows linking of related image derivatives and child snapshots.
 
 Length is defined by `GUID_SIZE`.
-| blockAlignmentShift | uint8_t | Determines block alignment boundaries using the formula 2 << blockAlignmentShift.
-| dataShift | uint8_t | Determines the maximum number of data items in a block using the formula 2 << dataShift.
-| tableShift | uint8_t | Shift used to calculate the number of sectors in a deduplication table entry, using the formula 2 << tableShift.
+| blockAlignmentShift | uint8_t | Determines block alignment boundaries using the formula 1 << blockAlignmentShift.
+| dataShift | uint8_t | Determines the maximum number of data items in a block using the formula 1 << dataShift.
+| tableShift | uint8_t | Shift used to calculate the number of sectors in a deduplication table entry, using the formula 1 << tableShift.
 | featureCompatible | uint64_t | Bitmask of features that, even if not implemented, still allow reading and writing the image.
 
 | featureCompatibleRo | uint64_t | Bitmask of features that allow read-only processing of the image if unsupported.


### PR DESCRIPTION
  All shift formulas in the spec use `2 << x` which equals `2^(x+1)`, but the code                                                                                                                                                                                                                                          
  unanimously uses `1 << x` (`2^x`). With default block_alignment=9, the spec claims                                                                                                                                                                                                                                        
  1024-byte alignment while the code produces 512 (standard sector size).                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                            
  Fixes `2 <<` → `1 <<` in:                                                                                                                                                                                                                                                                                                 
  - `docs/spec/blocks/ddt2.adoc` (5 occurrences + example calculation)                                                                                                                                                                                                                                                      
  - `docs/spec/blocks/header.adoc` (3 occurrences: blockAlignmentShift, dataShift, tableShift) 