### PR TITLE
spec: document BLAKE3 checksum algorithm (ID 5)

### DIFF
--- a/docs/spec/blocks/checksum.adoc
+++ b/docs/spec/blocks/checksum.adoc
@@ -102,4 +102,8 @@ typedef struct ChecksumEntry
 |SpamSum
 |4
 |SpamSum
+
+|Blake3
+|5
+|BLAKE3 (32-byte digest). Presence is indicated by the `AARU_FEATURE_RW_BLAKE3` bit (bit 0) in the header's `featureCompatible` field.
 |===


### PR DESCRIPTION
  Adds BLAKE3 (ID 5, 32-byte digest) to the checksum algorithms table.                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                          
  Presence is gated by the AARU_FEATURE_RW_BLAKE3 bit (bit 0) in the                                                                                                                                                                                                                                                        
  header's featureCompatible field.  