### PR TITLE
spec: clarify string encoding per block type

### DIFF
--- a/docs/spec/definitions.adoc
+++ b/docs/spec/definitions.adoc
@@ -25,7 +25,38 @@ And the unsigned integers should be: `uint8_t`, `uint16_t`, `uint32_t`, `uint64_
 
 === Strings
 
-All strings are stored as a sequence of bytes, in Unicode's `UTF-16` little endian encoding and terminated and filled with `NULL` (`0x00`) bytes.
+The default string encoding for the metadata block is `UTF-16` little endian, null-terminated with `0x0000`.
+
+Other blocks use different encodings as noted in their respective specifications:
+
+[cols="3,2,3",options="header"]
+|===
+|Location |Encoding |Notes
+
+|Metadata block (creator, comments, media/drive info)
+|UTF-16LE
+|Null-terminated (`0x0000`). Lengths include the terminator.
+
+|Header `application` field (V1)
+|UTF-16LE
+|Fixed 64-byte buffer (32 UTF-16 code units).
+
+|Header `application` field (V2+)
+|UTF-8
+|Fixed 64-byte buffer, null-padded.
+
+|Dump hardware strings (manufacturer, model, etc.)
+|UTF-8
+|Length-prefixed, not null-terminated on disk.
+
+|CICM XML block
+|UTF-8
+|Length from block header, not null-terminated.
+
+|Aaru JSON metadata block
+|UTF-8
+|Length from block header, not null-terminated.
+|===
 
 `String8` values mean the string is stored in Unicode’s `UTF-8` encoding and terminated and filled with `NULL` (`0x00`) bytes.
 


### PR DESCRIPTION
  The definitions section stated "all strings are UTF-16LE" which is incorrect.                                                                                                                                                                                                                                             
  Only metadata block strings use UTF-16LE. Other blocks use UTF-8 in current code base:                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                            
  - Header application field changed from UTF-16LE (V1) to UTF-8 (V2+)                                                                                                                                                                                                                                                      
  - Dump hardware strings are UTF-8, length-prefixed                                                                                                                                                                                                                                                                        
  - CICM XML and JSON metadata blocks are UTF-8                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                            
  Replaces the blanket statement with a table listing encoding per location,                                                                                                                                                                                                                                                
  including termination and length semantics.