### PR TITLE
Extend zstd compression to all sections, add featureIncompatible bit

### DIFF
--- a/include/aaruformat/consts.h
+++ b/include/aaruformat/consts.h
@@ -100,13 +100,14 @@
 #define CD_XFIX_MASK 0xFF000000U
 
 /** Bitmask of all featureIncompatible bits understood by this library version.
- *  Currently no incompatible features are defined. */
-#define AARUF_KNOWN_INCOMPAT_FEATURES   0ULL
+ *  Bit 0 = AARU_FEATURE_INCOMPAT_ZSTD (Zstandard compression). */
+#define AARUF_KNOWN_INCOMPAT_FEATURES   0x1ULL
 /** Bitmask of all featureCompatibleRo bits understood by this library version.
  *  Currently no read-only-compatible features are defined. */
 #define AARUF_KNOWN_ROCOMPAT_FEATURES   0ULL
-/** Bitmask of all featureCompatible bits understood by this library version. */
-#define AARUF_KNOWN_COMPAT_FEATURES     ((uint64_t)AARU_FEATURE_RW_BLAKE3)
+/** Bitmask of all featureCompatible bits understood by this library version.
+ *  Bit 0 = AARU_FEATURE_RW_BLAKE3 (BLAKE3 checksums). */
+#define AARUF_KNOWN_COMPAT_FEATURES     0x1ULL
 /** Mask for extracting positional index (lower 24 bits) in Compact Disc suffix/prefix deduplicated block entries. */
 #define CD_DFIX_MASK 0x00FFFFFFU
 

--- a/include/aaruformat/context.h
+++ b/include/aaruformat/context.h
@@ -302,6 +302,7 @@ typedef struct aaruformat_context
     bool     deduplicate;          ///< Storage deduplication active (duplicates coalesce).
     bool     compression_enabled;  ///< True if block compression enabled (writing path).
     bool     use_zstd;             ///< Use Zstandard instead of LZMA for data blocks.
+    bool     has_zstd_blocks;     ///< True if any block was actually written with Zstandard compression.
     int      zstd_level;           ///< Zstandard compression level (writing path, default 19).
     int      num_threads;          ///< Compression worker threads (1 = single-threaded, default).
 

--- a/include/aaruformat/enums.h
+++ b/include/aaruformat/enums.h
@@ -285,6 +285,19 @@ typedef enum
     AARU_FEATURE_RW_BLAKE3 = 0x1,  ///< BLAKE3 checksum is present (read/write support for BLAKE3 hashes).
 } FeaturesCompatible;
 
+/**
+ * @brief Incompatible feature flags for AaruHeader V2.
+ *
+ * If any bit in featureIncompatible is not understood by a reader, the image
+ * MUST NOT be opened (the reader cannot safely interpret the data).
+ *
+ * Future incompatible features SHALL use the next available bit (1ULL << n).
+ */
+typedef enum
+{
+    AARU_FEATURE_INCOMPAT_ZSTD = 0x1,  ///< Image contains Zstandard-compressed blocks.
+} FeaturesIncompatible;
+
 #ifndef _MSC_VER
 #pragma clang diagnostic pop
 #endif

--- a/src/blocks/flux.c
+++ b/src/blocks/flux.c
@@ -1020,6 +1020,76 @@ static int32_t read_lzma_compressed_payload(const aaruformat_context *ctx, size_
 }
 
 /**
+ * @brief Read and decompress a Zstandard-compressed flux payload.
+ *
+ * @param ctx       Image context (file stream positioned at start of compressed data).
+ * @param cmp_length Compressed payload length in bytes.
+ * @param raw_length Expected decompressed length in bytes.
+ * @param cmp_buffer Output: receives allocated buffer with compressed data (caller must free).
+ * @param payload    Output: receives allocated buffer with decompressed data (caller must free).
+ * @return AARUF_STATUS_OK on success; error code on failure.
+ * @internal
+ */
+static int32_t read_zstd_compressed_payload(const aaruformat_context *ctx, size_t cmp_length, size_t raw_length,
+                                            uint8_t **cmp_buffer, uint8_t **payload)
+{
+    if(cmp_length == 0)
+    {
+        FATAL("Flux payload compressed length is zero for zstd");
+        TRACE("Exiting read_zstd_compressed_payload() = AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK\n");
+        return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+    }
+
+    *cmp_buffer = (uint8_t *)malloc(cmp_length);
+    if(*cmp_buffer == NULL)
+    {
+        FATAL("Could not allocate %zu bytes for flux payload", cmp_length);
+        TRACE("Exiting read_zstd_compressed_payload() = AARUF_ERROR_NOT_ENOUGH_MEMORY\n");
+        return AARUF_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    size_t read_bytes = fread(*cmp_buffer, 1, cmp_length, ctx->imageStream);
+    if(read_bytes != cmp_length)
+    {
+        FATAL("Could not read %zu bytes of flux payload", cmp_length);
+        free(*cmp_buffer);
+        *cmp_buffer = NULL;
+        TRACE("Exiting read_zstd_compressed_payload() = AARUF_ERROR_CANNOT_READ_BLOCK\n");
+        return AARUF_ERROR_CANNOT_READ_BLOCK;
+    }
+
+    if(raw_length == 0)
+    {
+        *payload = NULL;
+        return AARUF_STATUS_OK;
+    }
+
+    *payload = (uint8_t *)malloc(raw_length);
+    if(*payload == NULL)
+    {
+        FATAL("Could not allocate %zu bytes for decompressed flux payload", raw_length);
+        free(*cmp_buffer);
+        *cmp_buffer = NULL;
+        TRACE("Exiting read_zstd_compressed_payload() = AARUF_ERROR_NOT_ENOUGH_MEMORY\n");
+        return AARUF_ERROR_NOT_ENOUGH_MEMORY;
+    }
+
+    size_t dst_len = aaruf_zstd_decode_buffer(*payload, raw_length, *cmp_buffer, cmp_length);
+    if(dst_len != raw_length)
+    {
+        FATAL("Zstd decompression failed for flux payload (dst=%zu/%zu)", dst_len, raw_length);
+        free(*payload);
+        free(*cmp_buffer);
+        *payload    = NULL;
+        *cmp_buffer = NULL;
+        TRACE("Exiting read_zstd_compressed_payload() = AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK\n");
+        return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+    }
+
+    return AARUF_STATUS_OK;
+}
+
+/**
  * @brief Validate CRC64 checksums for a flux payload block.
  *
  * @param cmp_buffer Compressed buffer to validate. Can be NULL if cmp_length is 0.
@@ -1275,6 +1345,10 @@ AARU_EXPORT int32_t AARU_CALL aaruf_read_flux_capture(void *context, uint32_t he
     else if(compression == kCompressionLzma)
     {
         res = read_lzma_compressed_payload(ctx, cmp_length, raw_length, &cmp_buffer, &payload);
+    }
+    else if(compression == kCompressionZstd)
+    {
+        res = read_zstd_compressed_payload(ctx, cmp_length, raw_length, &cmp_buffer, &payload);
     }
     else
     {

--- a/src/close.c
+++ b/src/close.c
@@ -108,7 +108,8 @@ static int32_t write_cached_secondary_ddt(aaruformat_context *ctx)
     DdtHeader2 ddt_header          = {0};
     ddt_header.identifier          = DeDuplicationTableSecondary;
     ddt_header.type                = kDataTypeUserData;
-    ddt_header.compression         = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    ddt_header.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     ddt_header.levels              = ctx->user_data_ddt_header.levels;
     ddt_header.tableLevel          = ctx->user_data_ddt_header.tableLevel + 1;
     ddt_header.previousLevelOffset = ctx->primary_ddt_offset;
@@ -157,12 +158,23 @@ static int32_t write_cached_secondary_ddt(aaruformat_context *ctx)
             return AARUF_ERROR_NOT_ENOUGH_MEMORY;
         }
 
-        size_t dst_size   = (size_t)ddt_header.length * 2 * 2;
-        size_t props_size = LZMA_PROPERTIES_LENGTH;
-        aaruf_lzma_encode_buffer(buffer, &dst_size,
+        size_t dst_size;
 
-                                 (uint8_t *)ctx->cached_secondary_ddt2, ddt_header.length, lzma_properties, &props_size,
-                                 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        if(ctx->use_zstd)
+        {
+            dst_size = aaruf_zstd_encode_buffer(buffer, (size_t)ddt_header.length * 2,
+                                                 (uint8_t *)ctx->cached_secondary_ddt2, ddt_header.length,
+                                                 ctx->zstd_level, ctx->num_threads);
+            if(dst_size == 0) dst_size = ddt_header.length;  // compression failed, fall through to None
+        }
+        else
+        {
+            dst_size          = (size_t)ddt_header.length * 2 * 2;
+            size_t props_size = LZMA_PROPERTIES_LENGTH;
+            aaruf_lzma_encode_buffer(buffer, &dst_size, (uint8_t *)ctx->cached_secondary_ddt2, ddt_header.length,
+                                     lzma_properties, &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273,
+                                     LZMA_THREADS(ctx));
+        }
 
         ddt_header.cmpLength = (uint32_t)dst_size;
 
@@ -180,7 +192,10 @@ static int32_t write_cached_secondary_ddt(aaruformat_context *ctx)
         ddt_header.cmpCrc64  = ddt_header.crc64;
     }
     else
+    {
         ddt_header.cmpCrc64 = aaruf_crc64_data(buffer, ddt_header.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     if(ddt_header.compression == kCompressionLzma) ddt_header.cmpLength += LZMA_PROPERTIES_LENGTH;
 
@@ -264,7 +279,7 @@ static int32_t write_cached_secondary_ddt(aaruformat_context *ctx)
     // Set position
     fseek(ctx->imageStream, 0, SEEK_END);
 
-    if(ddt_header.compression == kCompressionLzma) free(buffer);
+    if(ddt_header.compression != kCompressionNone) free(buffer);
 
     return AARUF_STATUS_OK;
 }
@@ -399,9 +414,10 @@ static int32_t write_single_level_ddt(aaruformat_context *ctx)
     const size_t primary_table_size = ctx->user_data_ddt_header.entries * sizeof(uint64_t);
 
     // Properly populate all header fields
-    ctx->user_data_ddt_header.identifier          = DeDuplicationTable2;
-    ctx->user_data_ddt_header.type                = kDataTypeUserData;
-    ctx->user_data_ddt_header.compression         = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    ctx->user_data_ddt_header.identifier  = DeDuplicationTable2;
+    ctx->user_data_ddt_header.type        = kDataTypeUserData;
+    ctx->user_data_ddt_header.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     ctx->user_data_ddt_header.levels              = 1;  // Single level
     ctx->user_data_ddt_header.tableLevel          = 0;  // Top level
     ctx->user_data_ddt_header.previousLevelOffset = 0;  // No previous level for single-level DDT
@@ -432,11 +448,23 @@ static int32_t write_single_level_ddt(aaruformat_context *ctx)
             return AARUF_ERROR_NOT_ENOUGH_MEMORY;
         }
 
-        size_t dst_size   = (size_t)ctx->user_data_ddt_header.length * 2 * 2;
-        size_t props_size = LZMA_PROPERTIES_LENGTH;
-        aaruf_lzma_encode_buffer(cmp_buffer, &dst_size, (uint8_t *)ctx->user_data_ddt2,
-                                 ctx->user_data_ddt_header.length, lzma_properties, &props_size, 9, ctx->lzma_dict_size,
-                                 4, 0, 2, 273, LZMA_THREADS(ctx));
+        size_t dst_size;
+
+        if(ctx->use_zstd)
+        {
+            dst_size = aaruf_zstd_encode_buffer(cmp_buffer, (size_t)ctx->user_data_ddt_header.length * 2,
+                                                 (uint8_t *)ctx->user_data_ddt2, ctx->user_data_ddt_header.length,
+                                                 ctx->zstd_level, ctx->num_threads);
+            if(dst_size == 0) dst_size = ctx->user_data_ddt_header.length;  // fall through to None
+        }
+        else
+        {
+            dst_size          = (size_t)ctx->user_data_ddt_header.length * 2 * 2;
+            size_t props_size = LZMA_PROPERTIES_LENGTH;
+            aaruf_lzma_encode_buffer(cmp_buffer, &dst_size, (uint8_t *)ctx->user_data_ddt2,
+                                     ctx->user_data_ddt_header.length, lzma_properties, &props_size, 9,
+                                     ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        }
 
         ctx->user_data_ddt_header.cmpLength = (uint32_t)dst_size;
 
@@ -455,8 +483,11 @@ static int32_t write_single_level_ddt(aaruformat_context *ctx)
         ctx->user_data_ddt_header.cmpCrc64  = ctx->user_data_ddt_header.crc64;
     }
     else
+    {
         ctx->user_data_ddt_header.cmpCrc64 =
             aaruf_crc64_data(cmp_buffer, (uint32_t)ctx->user_data_ddt_header.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     if(ctx->user_data_ddt_header.compression == kCompressionLzma)
         ctx->user_data_ddt_header.cmpLength += LZMA_PROPERTIES_LENGTH;
@@ -644,9 +675,10 @@ static int32_t write_tape_ddt(aaruformat_context *ctx)
     if(entry->key > max_key) max_key = entry->key;
 
     // Initialize context user data DDT header
-    ctx->user_data_ddt_header.identifier          = DeDuplicationTable2;
-    ctx->user_data_ddt_header.type                = kDataTypeUserData;
-    ctx->user_data_ddt_header.compression         = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    ctx->user_data_ddt_header.identifier  = DeDuplicationTable2;
+    ctx->user_data_ddt_header.type        = kDataTypeUserData;
+    ctx->user_data_ddt_header.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     ctx->user_data_ddt_header.levels              = 1;  // Single level
     ctx->user_data_ddt_header.tableLevel          = 0;  // Top level
     ctx->user_data_ddt_header.previousLevelOffset = 0;  // No previous level for single-level DDT
@@ -934,7 +966,8 @@ static void write_mode2_subheaders_block(aaruformat_context *ctx)
     BlockHeader subheaders_block = {0};
     subheaders_block.identifier  = DataBlock;
     subheaders_block.type        = kDataTypeCdSubHeader;
-    subheaders_block.compression = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    subheaders_block.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     subheaders_block.length =
         (uint32_t)(ctx->user_data_ddt_header.negative + ctx->image_info.Sectors + ctx->user_data_ddt_header.overflow) *
         8;
@@ -959,10 +992,21 @@ static void write_mode2_subheaders_block(aaruformat_context *ctx)
             return;
         }
 
-        size_t dst_size   = (size_t)subheaders_block.length * 2 * 2;
-        size_t props_size = LZMA_PROPERTIES_LENGTH;
-        aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->mode2_subheaders, subheaders_block.length, lzma_properties,
-                                 &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        size_t dst_size;
+
+        if(ctx->use_zstd)
+        {
+            dst_size = aaruf_zstd_encode_buffer(buffer, (size_t)subheaders_block.length * 2, ctx->mode2_subheaders,
+                                                 subheaders_block.length, ctx->zstd_level, ctx->num_threads);
+            if(dst_size == 0) dst_size = subheaders_block.length;
+        }
+        else
+        {
+            dst_size          = (size_t)subheaders_block.length * 2 * 2;
+            size_t props_size = LZMA_PROPERTIES_LENGTH;
+            aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->mode2_subheaders, subheaders_block.length, lzma_properties,
+                                     &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        }
 
         subheaders_block.cmpLength = (uint32_t)dst_size;
 
@@ -980,7 +1024,10 @@ static void write_mode2_subheaders_block(aaruformat_context *ctx)
         subheaders_block.cmpCrc64  = subheaders_block.crc64;
     }
     else
+    {
         subheaders_block.cmpCrc64 = aaruf_crc64_data(buffer, subheaders_block.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     const size_t length_to_write = subheaders_block.cmpLength;
     if(subheaders_block.compression == kCompressionLzma) subheaders_block.cmpLength += LZMA_PROPERTIES_LENGTH;
@@ -1021,7 +1068,7 @@ static void write_mode2_subheaders_block(aaruformat_context *ctx)
         }
     }
 
-    if(subheaders_block.compression == kCompressionLzma) free(buffer);
+    if(subheaders_block.compression != kCompressionNone) free(buffer);
 }
 
 /**
@@ -1065,7 +1112,8 @@ static void write_sector_prefix(aaruformat_context *ctx)
     BlockHeader prefix_block = {0};
     prefix_block.identifier  = DataBlock;
     prefix_block.type        = kDataTypeCdSectorPrefix;
-    prefix_block.compression = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    prefix_block.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     prefix_block.length      = (uint32_t)ctx->sector_prefix_offset;
 
     // Calculate CRC64
@@ -1088,10 +1136,21 @@ static void write_sector_prefix(aaruformat_context *ctx)
             return;
         }
 
-        size_t dst_size   = (size_t)prefix_block.length * 2 * 2;
-        size_t props_size = LZMA_PROPERTIES_LENGTH;
-        aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_prefix, prefix_block.length, lzma_properties,
-                                 &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        size_t dst_size;
+
+        if(ctx->use_zstd)
+        {
+            dst_size = aaruf_zstd_encode_buffer(buffer, (size_t)prefix_block.length * 2, ctx->sector_prefix,
+                                                 prefix_block.length, ctx->zstd_level, ctx->num_threads);
+            if(dst_size == 0) dst_size = prefix_block.length;
+        }
+        else
+        {
+            dst_size          = (size_t)prefix_block.length * 2 * 2;
+            size_t props_size = LZMA_PROPERTIES_LENGTH;
+            aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_prefix, prefix_block.length, lzma_properties,
+                                     &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        }
 
         prefix_block.cmpLength = (uint32_t)dst_size;
 
@@ -1109,7 +1168,10 @@ static void write_sector_prefix(aaruformat_context *ctx)
         prefix_block.cmpCrc64  = prefix_block.crc64;
     }
     else
+    {
         prefix_block.cmpCrc64 = aaruf_crc64_data(buffer, prefix_block.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     const size_t length_to_write = prefix_block.cmpLength;
     if(prefix_block.compression == kCompressionLzma) prefix_block.cmpLength += LZMA_PROPERTIES_LENGTH;
@@ -1150,7 +1212,7 @@ static void write_sector_prefix(aaruformat_context *ctx)
         }
     }
 
-    if(prefix_block.compression == kCompressionLzma) free(buffer);
+    if(prefix_block.compression != kCompressionNone) free(buffer);
 }
 
 /**
@@ -1203,7 +1265,8 @@ static void write_sector_suffix(aaruformat_context *ctx)
     BlockHeader suffix_block = {0};
     suffix_block.identifier  = DataBlock;
     suffix_block.type        = kDataTypeCdSectorSuffix;
-    suffix_block.compression = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    suffix_block.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     suffix_block.length      = (uint32_t)ctx->sector_suffix_offset;
 
     // Calculate CRC64
@@ -1226,10 +1289,21 @@ static void write_sector_suffix(aaruformat_context *ctx)
             return;
         }
 
-        size_t dst_size   = (size_t)suffix_block.length * 2 * 2;
-        size_t props_size = LZMA_PROPERTIES_LENGTH;
-        aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_suffix, suffix_block.length, lzma_properties,
-                                 &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        size_t dst_size;
+
+        if(ctx->use_zstd)
+        {
+            dst_size = aaruf_zstd_encode_buffer(buffer, (size_t)suffix_block.length * 2, ctx->sector_suffix,
+                                                 suffix_block.length, ctx->zstd_level, ctx->num_threads);
+            if(dst_size == 0) dst_size = suffix_block.length;
+        }
+        else
+        {
+            dst_size          = (size_t)suffix_block.length * 2 * 2;
+            size_t props_size = LZMA_PROPERTIES_LENGTH;
+            aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_suffix, suffix_block.length, lzma_properties,
+                                     &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        }
 
         suffix_block.cmpLength = (uint32_t)dst_size;
 
@@ -1247,7 +1321,10 @@ static void write_sector_suffix(aaruformat_context *ctx)
         suffix_block.cmpCrc64  = suffix_block.crc64;
     }
     else
+    {
         suffix_block.cmpCrc64 = aaruf_crc64_data(buffer, suffix_block.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     const size_t length_to_write = suffix_block.cmpLength;
     if(suffix_block.compression == kCompressionLzma) suffix_block.cmpLength += LZMA_PROPERTIES_LENGTH;
@@ -1288,7 +1365,7 @@ static void write_sector_suffix(aaruformat_context *ctx)
         }
     }
 
-    if(suffix_block.compression == kCompressionLzma) free(buffer);
+    if(suffix_block.compression != kCompressionNone) free(buffer);
 }
 
 /**
@@ -1336,8 +1413,9 @@ static void write_sector_prefix_ddt(aaruformat_context *ctx)
     TRACE("Writing sector prefix DDT v2 at position %ld", prefix_ddt_position);
     DdtHeader2 ddt_header2          = {0};
     ddt_header2.identifier          = DeDuplicationTable2;
-    ddt_header2.type                = kDataTypeCdSectorPrefix;
-    ddt_header2.compression         = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    ddt_header2.type        = kDataTypeCdSectorPrefix;
+    ddt_header2.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     ddt_header2.levels              = 1;
     ddt_header2.tableLevel          = 0;
     ddt_header2.negative            = ctx->user_data_ddt_header.negative;
@@ -1370,10 +1448,23 @@ static void write_sector_prefix_ddt(aaruformat_context *ctx)
             return;
         }
 
-        size_t dst_size   = (size_t)ddt_header2.length * 2 * 2;
-        size_t props_size = LZMA_PROPERTIES_LENGTH;
-        aaruf_lzma_encode_buffer(buffer, &dst_size, (uint8_t *)ctx->sector_prefix_ddt2, ddt_header2.length,
-                                 lzma_properties, &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        size_t dst_size;
+
+        if(ctx->use_zstd)
+        {
+            dst_size = aaruf_zstd_encode_buffer(buffer, (size_t)ddt_header2.length * 2,
+                                                 (uint8_t *)ctx->sector_prefix_ddt2, ddt_header2.length,
+                                                 ctx->zstd_level, ctx->num_threads);
+            if(dst_size == 0) dst_size = ddt_header2.length;
+        }
+        else
+        {
+            dst_size          = (size_t)ddt_header2.length * 2 * 2;
+            size_t props_size = LZMA_PROPERTIES_LENGTH;
+            aaruf_lzma_encode_buffer(buffer, &dst_size, (uint8_t *)ctx->sector_prefix_ddt2, ddt_header2.length,
+                                     lzma_properties, &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273,
+                                     LZMA_THREADS(ctx));
+        }
 
         ddt_header2.cmpLength = (uint32_t)dst_size;
 
@@ -1391,7 +1482,10 @@ static void write_sector_prefix_ddt(aaruformat_context *ctx)
         ddt_header2.cmpCrc64  = ddt_header2.crc64;
     }
     else
+    {
         ddt_header2.cmpCrc64 = aaruf_crc64_data(buffer, (uint32_t)ddt_header2.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     const size_t length_to_write = ddt_header2.cmpLength;
     if(ddt_header2.compression == kCompressionLzma) ddt_header2.cmpLength += LZMA_PROPERTIES_LENGTH;
@@ -1432,7 +1526,7 @@ static void write_sector_prefix_ddt(aaruformat_context *ctx)
         }
     }
 
-    if(ddt_header2.compression == kCompressionLzma) free(buffer);
+    if(ddt_header2.compression != kCompressionNone) free(buffer);
 }
 
 /**
@@ -1496,8 +1590,9 @@ static void write_sector_suffix_ddt(aaruformat_context *ctx)
     TRACE("Writing sector suffix DDT v2 at position %ld", suffix_ddt_position);
     DdtHeader2 ddt_header2          = {0};
     ddt_header2.identifier          = DeDuplicationTable2;
-    ddt_header2.type                = kDataTypeCdSectorSuffix;
-    ddt_header2.compression         = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    ddt_header2.type        = kDataTypeCdSectorSuffix;
+    ddt_header2.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     ddt_header2.levels              = 1;
     ddt_header2.tableLevel          = 0;
     ddt_header2.negative            = ctx->user_data_ddt_header.negative;
@@ -1530,10 +1625,23 @@ static void write_sector_suffix_ddt(aaruformat_context *ctx)
             return;
         }
 
-        size_t dst_size   = (size_t)ddt_header2.length * 2 * 2;
-        size_t props_size = LZMA_PROPERTIES_LENGTH;
-        aaruf_lzma_encode_buffer(buffer, &dst_size, (uint8_t *)ctx->sector_suffix_ddt2, ddt_header2.length,
-                                 lzma_properties, &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        size_t dst_size;
+
+        if(ctx->use_zstd)
+        {
+            dst_size = aaruf_zstd_encode_buffer(buffer, (size_t)ddt_header2.length * 2,
+                                                 (uint8_t *)ctx->sector_suffix_ddt2, ddt_header2.length,
+                                                 ctx->zstd_level, ctx->num_threads);
+            if(dst_size == 0) dst_size = ddt_header2.length;
+        }
+        else
+        {
+            dst_size          = (size_t)ddt_header2.length * 2 * 2;
+            size_t props_size = LZMA_PROPERTIES_LENGTH;
+            aaruf_lzma_encode_buffer(buffer, &dst_size, (uint8_t *)ctx->sector_suffix_ddt2, ddt_header2.length,
+                                     lzma_properties, &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273,
+                                     LZMA_THREADS(ctx));
+        }
 
         ddt_header2.cmpLength = (uint32_t)dst_size;
 
@@ -1551,7 +1659,10 @@ static void write_sector_suffix_ddt(aaruformat_context *ctx)
         ddt_header2.cmpCrc64  = ddt_header2.crc64;
     }
     else
+    {
         ddt_header2.cmpCrc64 = aaruf_crc64_data(buffer, (uint32_t)ddt_header2.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     const size_t length_to_write = ddt_header2.cmpLength;
     if(ddt_header2.compression == kCompressionLzma) ddt_header2.cmpLength += LZMA_PROPERTIES_LENGTH;
@@ -1592,7 +1703,7 @@ static void write_sector_suffix_ddt(aaruformat_context *ctx)
         }
     }
 
-    if(ddt_header2.compression == kCompressionLzma) free(buffer);
+    if(ddt_header2.compression != kCompressionNone) free(buffer);
 }
 
 /**
@@ -1813,7 +1924,10 @@ static void write_sector_subchannel(aaruformat_context *ctx)
     if(subchannel_block.compression == kCompressionNone)
         subchannel_block.cmpCrc64 = subchannel_block.crc64;
     else
+    {
         subchannel_block.cmpCrc64 = aaruf_crc64_data(buffer, subchannel_block.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     const size_t length_to_write = subchannel_block.cmpLength;
     const bool   has_lzma_props = subchannel_block.compression == kCompressionLzma ||
@@ -2017,7 +2131,8 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
     BlockHeader id_block = {0};
     id_block.identifier  = DataBlock;
     id_block.type        = kDataTypeDvdSectorId;
-    id_block.compression = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    id_block.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     id_block.length      = (uint32_t)total_sectors * 4;
 
     // Calculate CRC64
@@ -2040,10 +2155,21 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
             return;
         }
 
-        size_t dst_size   = (size_t)id_block.length * 2 * 2;
-        size_t props_size = LZMA_PROPERTIES_LENGTH;
-        aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_id, id_block.length, lzma_properties, &props_size, 9,
-                                 ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        size_t dst_size;
+
+        if(ctx->use_zstd)
+        {
+            dst_size = aaruf_zstd_encode_buffer(buffer, (size_t)id_block.length * 2, ctx->sector_id, id_block.length,
+                                                 ctx->zstd_level, ctx->num_threads);
+            if(dst_size == 0) dst_size = id_block.length;
+        }
+        else
+        {
+            dst_size          = (size_t)id_block.length * 2 * 2;
+            size_t props_size = LZMA_PROPERTIES_LENGTH;
+            aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_id, id_block.length, lzma_properties, &props_size,
+                                     9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        }
 
         id_block.cmpLength = (uint32_t)dst_size;
 
@@ -2061,7 +2187,10 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
         id_block.cmpCrc64  = id_block.crc64;
     }
     else
+    {
         id_block.cmpCrc64 = aaruf_crc64_data(buffer, id_block.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     size_t length_to_write = id_block.cmpLength;
     if(id_block.compression == kCompressionLzma) id_block.cmpLength += LZMA_PROPERTIES_LENGTH;
@@ -2102,7 +2231,7 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
         }
     }
 
-    if(id_block.compression == kCompressionLzma) free(buffer);
+    if(id_block.compression != kCompressionNone) free(buffer);
 
     // Write DVD sector IED block
     fseek(ctx->imageStream, 0, SEEK_END);
@@ -2117,7 +2246,8 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
     BlockHeader ied_block = {0};
     ied_block.identifier  = DataBlock;
     ied_block.type        = kDataTypeDvdSectorIed;
-    ied_block.compression = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    ied_block.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     ied_block.length      = (uint32_t)total_sectors * 2;
     // Calculate CRC64
     ied_block.crc64       = aaruf_crc64_data(ctx->sector_ied, ied_block.length);
@@ -2138,10 +2268,21 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
             return;
         }
 
-        size_t dst_size   = (size_t)ied_block.length * 2 * 2;
-        size_t props_size = LZMA_PROPERTIES_LENGTH;
-        aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_ied, ied_block.length, lzma_properties, &props_size, 9,
-                                 ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        size_t dst_size;
+
+        if(ctx->use_zstd)
+        {
+            dst_size = aaruf_zstd_encode_buffer(buffer, (size_t)ied_block.length * 2, ctx->sector_ied,
+                                                 ied_block.length, ctx->zstd_level, ctx->num_threads);
+            if(dst_size == 0) dst_size = ied_block.length;
+        }
+        else
+        {
+            dst_size          = (size_t)ied_block.length * 2 * 2;
+            size_t props_size = LZMA_PROPERTIES_LENGTH;
+            aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_ied, ied_block.length, lzma_properties, &props_size,
+                                     9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        }
 
         ied_block.cmpLength = (uint32_t)dst_size;
 
@@ -2159,7 +2300,10 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
         ied_block.cmpCrc64  = ied_block.crc64;
     }
     else
+    {
         ied_block.cmpCrc64 = aaruf_crc64_data(buffer, ied_block.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     length_to_write = ied_block.cmpLength;
     if(ied_block.compression == kCompressionLzma) ied_block.cmpLength += LZMA_PROPERTIES_LENGTH;
@@ -2200,7 +2344,7 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
         }
     }
 
-    if(ied_block.compression == kCompressionLzma) free(buffer);
+    if(ied_block.compression != kCompressionNone) free(buffer);
 
     // Write DVD sector CPR/MAI block
     fseek(ctx->imageStream, 0, SEEK_END);
@@ -2215,7 +2359,8 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
     BlockHeader cpr_mai_block = {0};
     cpr_mai_block.identifier  = DataBlock;
     cpr_mai_block.type        = kDataTypeDvdSectorCprMai;
-    cpr_mai_block.compression = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    cpr_mai_block.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     cpr_mai_block.length      = (uint32_t)total_sectors * 6;
     // Calculate CRC64
     cpr_mai_block.crc64       = aaruf_crc64_data(ctx->sector_cpr_mai, cpr_mai_block.length);
@@ -2236,10 +2381,21 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
             return;
         }
 
-        size_t dst_size   = (size_t)cpr_mai_block.length * 2 * 2;
-        size_t props_size = LZMA_PROPERTIES_LENGTH;
-        aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_cpr_mai, cpr_mai_block.length, lzma_properties,
-                                 &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        size_t dst_size;
+
+        if(ctx->use_zstd)
+        {
+            dst_size = aaruf_zstd_encode_buffer(buffer, (size_t)cpr_mai_block.length * 2, ctx->sector_cpr_mai,
+                                                 cpr_mai_block.length, ctx->zstd_level, ctx->num_threads);
+            if(dst_size == 0) dst_size = cpr_mai_block.length;
+        }
+        else
+        {
+            dst_size          = (size_t)cpr_mai_block.length * 2 * 2;
+            size_t props_size = LZMA_PROPERTIES_LENGTH;
+            aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_cpr_mai, cpr_mai_block.length, lzma_properties,
+                                     &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        }
 
         cpr_mai_block.cmpLength = (uint32_t)dst_size;
 
@@ -2257,7 +2413,10 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
         cpr_mai_block.cmpCrc64  = cpr_mai_block.crc64;
     }
     else
+    {
         cpr_mai_block.cmpCrc64 = aaruf_crc64_data(buffer, cpr_mai_block.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     length_to_write = cpr_mai_block.cmpLength;
     if(cpr_mai_block.compression == kCompressionLzma) cpr_mai_block.cmpLength += LZMA_PROPERTIES_LENGTH;
@@ -2298,7 +2457,7 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
         }
     }
 
-    if(cpr_mai_block.compression == kCompressionLzma) free(buffer);
+    if(cpr_mai_block.compression != kCompressionNone) free(buffer);
 
     // Write DVD sector EDC block
     fseek(ctx->imageStream, 0, SEEK_END);
@@ -2313,7 +2472,8 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
     BlockHeader edc_block = {0};
     edc_block.identifier  = DataBlock;
     edc_block.type        = kDataTypeDvdSectorEdc;
-    edc_block.compression = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    edc_block.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     edc_block.length      = (uint32_t)total_sectors * 4;
     // Calculate CRC64
     edc_block.crc64       = aaruf_crc64_data(ctx->sector_edc, edc_block.length);
@@ -2334,10 +2494,21 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
             return;
         }
 
-        size_t dst_size   = (size_t)edc_block.length * 2 * 2;
-        size_t props_size = LZMA_PROPERTIES_LENGTH;
-        aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_edc, edc_block.length, lzma_properties, &props_size, 9,
-                                 ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        size_t dst_size;
+
+        if(ctx->use_zstd)
+        {
+            dst_size = aaruf_zstd_encode_buffer(buffer, (size_t)edc_block.length * 2, ctx->sector_edc,
+                                                 edc_block.length, ctx->zstd_level, ctx->num_threads);
+            if(dst_size == 0) dst_size = edc_block.length;
+        }
+        else
+        {
+            dst_size          = (size_t)edc_block.length * 2 * 2;
+            size_t props_size = LZMA_PROPERTIES_LENGTH;
+            aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_edc, edc_block.length, lzma_properties,
+                                     &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        }
 
         edc_block.cmpLength = (uint32_t)dst_size;
 
@@ -2355,7 +2526,10 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
         edc_block.cmpCrc64  = edc_block.crc64;
     }
     else
+    {
         edc_block.cmpCrc64 = aaruf_crc64_data(buffer, edc_block.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     length_to_write = edc_block.cmpLength;
     if(edc_block.compression == kCompressionLzma) edc_block.cmpLength += LZMA_PROPERTIES_LENGTH;
@@ -2396,7 +2570,7 @@ void write_dvd_long_sector_blocks(aaruformat_context *ctx)
         }
     }
 
-    if(edc_block.compression == kCompressionLzma) free(buffer);
+    if(edc_block.compression != kCompressionNone) free(buffer);
 }
 
 /**
@@ -2513,7 +2687,8 @@ static void write_dvd_title_key_decrypted_block(aaruformat_context *ctx)
     BlockHeader decrypted_title_key_block = {0};
     decrypted_title_key_block.identifier  = DataBlock;
     decrypted_title_key_block.type        = kDataTypeDvdTitleKeyDecrypted;
-    decrypted_title_key_block.compression = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    decrypted_title_key_block.compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
     decrypted_title_key_block.length =
         (uint32_t)(ctx->user_data_ddt_header.negative + ctx->image_info.Sectors + ctx->user_data_ddt_header.overflow) *
         5;
@@ -2538,10 +2713,23 @@ static void write_dvd_title_key_decrypted_block(aaruformat_context *ctx)
             return;
         }
 
-        size_t dst_size   = (size_t)decrypted_title_key_block.length * 2 * 2;
-        size_t props_size = LZMA_PROPERTIES_LENGTH;
-        aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_decrypted_title_key, decrypted_title_key_block.length,
-                                 lzma_properties, &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        size_t dst_size;
+
+        if(ctx->use_zstd)
+        {
+            dst_size = aaruf_zstd_encode_buffer(buffer, (size_t)decrypted_title_key_block.length * 2,
+                                                 ctx->sector_decrypted_title_key, decrypted_title_key_block.length,
+                                                 ctx->zstd_level, ctx->num_threads);
+            if(dst_size == 0) dst_size = decrypted_title_key_block.length;
+        }
+        else
+        {
+            dst_size          = (size_t)decrypted_title_key_block.length * 2 * 2;
+            size_t props_size = LZMA_PROPERTIES_LENGTH;
+            aaruf_lzma_encode_buffer(buffer, &dst_size, ctx->sector_decrypted_title_key,
+                                     decrypted_title_key_block.length, lzma_properties, &props_size, 9,
+                                     ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+        }
 
         decrypted_title_key_block.cmpLength = (uint32_t)dst_size;
 
@@ -2559,7 +2747,10 @@ static void write_dvd_title_key_decrypted_block(aaruformat_context *ctx)
         decrypted_title_key_block.cmpCrc64  = decrypted_title_key_block.crc64;
     }
     else
+    {
         decrypted_title_key_block.cmpCrc64 = aaruf_crc64_data(buffer, decrypted_title_key_block.cmpLength);
+        if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+    }
 
     const size_t length_to_write = decrypted_title_key_block.cmpLength;
     if(decrypted_title_key_block.compression == kCompressionLzma)
@@ -2602,7 +2793,7 @@ static void write_dvd_title_key_decrypted_block(aaruformat_context *ctx)
         }
     }
 
-    if(decrypted_title_key_block.compression == kCompressionLzma) free(buffer);
+    if(decrypted_title_key_block.compression != kCompressionNone) free(buffer);
 }
 
 /**
@@ -2700,7 +2891,8 @@ static void write_media_tags(aaruformat_context *ctx)
         BlockHeader tag_block = {0};
         tag_block.identifier  = DataBlock;
         tag_block.type        = (uint16_t)aaruf_get_datatype_for_media_tag_type(media_tag->type);
-        tag_block.compression = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+        tag_block.compression =
+            ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
         tag_block.length      = media_tag->length;
 
         // Calculate CRC64
@@ -2723,10 +2915,21 @@ static void write_media_tags(aaruformat_context *ctx)
                 return;
             }
 
-            size_t dst_size   = (size_t)tag_block.length * 2 * 2;
-            size_t props_size = LZMA_PROPERTIES_LENGTH;
-            aaruf_lzma_encode_buffer(buffer, &dst_size, media_tag->data, tag_block.length, lzma_properties, &props_size,
-                                     9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+            size_t dst_size;
+
+            if(ctx->use_zstd)
+            {
+                dst_size = aaruf_zstd_encode_buffer(buffer, (size_t)tag_block.length * 2, media_tag->data,
+                                                     tag_block.length, ctx->zstd_level, ctx->num_threads);
+                if(dst_size == 0) dst_size = tag_block.length;
+            }
+            else
+            {
+                dst_size          = (size_t)tag_block.length * 2 * 2;
+                size_t props_size = LZMA_PROPERTIES_LENGTH;
+                aaruf_lzma_encode_buffer(buffer, &dst_size, media_tag->data, tag_block.length, lzma_properties,
+                                         &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+            }
 
             tag_block.cmpLength = (uint32_t)dst_size;
 
@@ -2744,7 +2947,10 @@ static void write_media_tags(aaruformat_context *ctx)
             tag_block.cmpCrc64  = tag_block.crc64;
         }
         else
+        {
             tag_block.cmpCrc64 = aaruf_crc64_data(buffer, tag_block.cmpLength);
+            if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+        }
 
         const size_t length_to_write = tag_block.cmpLength;
         if(tag_block.compression == kCompressionLzma) tag_block.cmpLength += LZMA_PROPERTIES_LENGTH;
@@ -2786,7 +2992,7 @@ static void write_media_tags(aaruformat_context *ctx)
             }
         }
 
-        if(tag_block.compression == kCompressionLzma) free(buffer);
+        if(tag_block.compression != kCompressionNone) free(buffer);
     }
 }
 
@@ -4436,7 +4642,8 @@ static int32_t write_flux_capture_payload(aaruformat_context *ctx, FluxCaptureRe
 
     uint64_t raw_crc = raw_length != 0 && raw_buffer != NULL ? aaruf_crc64_data(raw_buffer, raw_length) : 0;
 
-    CompressionType compression = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+    CompressionType compression =
+        ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
 
     uint8_t *compressed_buffer = NULL;
     uint32_t cmp_length        = 0;
@@ -4484,6 +4691,38 @@ static int32_t write_flux_capture_payload(aaruformat_context *ctx, FluxCaptureRe
             memcpy(compressed_buffer + LZMA_PROPERTIES_LENGTH, cmp_stream, dst_size);
             cmp_crc = aaruf_crc64_data(compressed_buffer, cmp_length);
             free(cmp_stream);
+            free(raw_buffer);
+            raw_buffer = NULL;
+        }
+    }
+    else if(compression == kCompressionZstd)
+    {
+        size_t cmp_capacity = raw_length ? raw_length * 2 + 65536 : 16;
+
+        uint8_t *cmp_stream = malloc(cmp_capacity);
+        if(cmp_stream == NULL)
+        {
+            free(raw_buffer);
+            FATAL("Could not allocate %zu bytes for zstd flux compression", cmp_capacity);
+            return AARUF_ERROR_NOT_ENOUGH_MEMORY;
+        }
+
+        size_t dst_size =
+            aaruf_zstd_encode_buffer(cmp_stream, cmp_capacity, raw_buffer, raw_length, ctx->zstd_level, ctx->num_threads);
+
+        if(dst_size == 0 || dst_size >= raw_length)
+        {
+            TRACE("Flux capture zstd compression fell back to uncompressed (dst=%zu, raw=%" PRIu64 ")", dst_size,
+                  raw_length);
+            compression = kCompressionNone;
+            free(cmp_stream);
+        }
+        else
+        {
+            cmp_length        = (uint32_t)dst_size;
+            compressed_buffer      = cmp_stream;
+            cmp_crc                = aaruf_crc64_data(compressed_buffer, cmp_length);
+            ctx->has_zstd_blocks = true;
             free(raw_buffer);
             raw_buffer = NULL;
         }
@@ -5073,6 +5312,8 @@ AARU_EXPORT int AARU_CALL aaruf_close(void *context)
     if(ctx->is_writing)
     {
         TRACE("File is writing");
+
+        if(ctx->has_zstd_blocks) ctx->header.featureIncompatible |= AARU_FEATURE_INCOMPAT_ZSTD;
 
         TRACE("Seeking to start of image");
         // Write the header at the beginning of the file

--- a/src/ddt/ddt_v1.c
+++ b/src/ddt/ddt_v1.c
@@ -215,6 +215,50 @@ int32_t process_ddt_v1(aaruformat_context *ctx, IndexEntry *entry, bool *found_u
                 *found_user_data_ddt = true;
 
                 break;
+            case kCompressionZstd:
+                cmp_data = (uint8_t *)malloc(ddt_header.cmpLength);
+                if(cmp_data == NULL)
+                {
+                    TRACE("Cannot allocate memory for DDT, continuing...");
+                    break;
+                }
+
+                ctx->user_data_ddt = (uint64_t *)malloc(ddt_header.length);
+                if(ctx->user_data_ddt == NULL)
+                {
+                    TRACE("Cannot allocate memory for DDT, continuing...");
+                    free(cmp_data);
+                    break;
+                }
+
+                read_bytes = fread(cmp_data, 1, ddt_header.cmpLength, ctx->imageStream);
+                if(read_bytes != ddt_header.cmpLength)
+                {
+                    TRACE("Could not read compressed block, continuing...");
+                    free(cmp_data);
+                    free(ctx->user_data_ddt);
+                    ctx->user_data_ddt = NULL;
+                    break;
+                }
+
+                read_bytes = aaruf_zstd_decode_buffer((uint8_t *)ctx->user_data_ddt, ddt_header.length, cmp_data,
+                                                       ddt_header.cmpLength);
+                if(read_bytes != ddt_header.length)
+                {
+                    FATAL("Error decompressing zstd DDT block, expected %zu got %zu", ddt_header.length, read_bytes);
+                    free(cmp_data);
+                    free(ctx->user_data_ddt);
+                    ctx->user_data_ddt = NULL;
+                    return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+                }
+
+                free(cmp_data);
+                cmp_data = NULL;
+
+                ctx->in_memory_ddt   = true;
+                *found_user_data_ddt = true;
+
+                break;
             // TODO: Check CRC
             case kCompressionNone:
                 ctx->user_data_ddt = (uint64_t *)malloc(ddt_header.length);
@@ -306,6 +350,52 @@ int32_t process_ddt_v1(aaruformat_context *ctx, IndexEntry *entry, bool *found_u
                 if(read_bytes != ddt_header.length)
                 {
                     FATAL("Error decompressing block, should be {0} bytes but got {1} bytes., stopping...");
+                    free(cmp_data);
+                    free(cd_ddt);
+                    return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+                }
+
+                free(cmp_data);
+                cmp_data = NULL;
+
+                if(entry->dataType == kDataTypeCdSectorPrefixCorrected)
+                    ctx->sector_prefix_ddt = cd_ddt;
+                else if(entry->dataType == kDataTypeCdSectorSuffixCorrected)
+                    ctx->sector_suffix_ddt = cd_ddt;
+                else
+                    free(cd_ddt);
+
+                break;
+            case kCompressionZstd:
+                cmp_data = (uint8_t *)malloc(ddt_header.cmpLength);
+                if(cmp_data == NULL)
+                {
+                    TRACE("Cannot allocate memory for DDT, continuing...");
+                    break;
+                }
+
+                cd_ddt = (uint32_t *)malloc(ddt_header.length);
+                if(cd_ddt == NULL)
+                {
+                    TRACE("Cannot allocate memory for DDT, continuing...");
+                    free(cmp_data);
+                    break;
+                }
+
+                read_bytes = fread(cmp_data, 1, ddt_header.cmpLength, ctx->imageStream);
+                if(read_bytes != ddt_header.cmpLength)
+                {
+                    TRACE("Could not read compressed block, continuing...");
+                    free(cmp_data);
+                    free(cd_ddt);
+                    break;
+                }
+
+                read_bytes = aaruf_zstd_decode_buffer((uint8_t *)cd_ddt, ddt_header.length, cmp_data,
+                                                       ddt_header.cmpLength);
+                if(read_bytes != ddt_header.length)
+                {
+                    FATAL("Error decompressing zstd DDT block, expected %zu got %zu", ddt_header.length, read_bytes);
                     free(cmp_data);
                     free(cd_ddt);
                     return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;

--- a/src/ddt/ddt_v2.c
+++ b/src/ddt/ddt_v2.c
@@ -251,6 +251,80 @@ int32_t process_ddt_v2(aaruformat_context *ctx, IndexEntry *entry, bool *found_u
                 *found_user_data_ddt = true;
 
                 break;
+            case kCompressionZstd:
+                if(ddt_header.cmpLength == 0)
+                {
+                    FATAL("Compressed DDT payload has zero length for zstd.");
+                    TRACE("Exiting process_ddt_v2() = AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK");
+                    return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+                }
+
+                cmp_data = (uint8_t *)malloc(ddt_header.cmpLength);
+                if(cmp_data == NULL)
+                {
+                    TRACE("Cannot allocate memory for DDT, continuing...");
+                    break;
+                }
+
+                buffer = malloc(ddt_header.length);
+                if(buffer == NULL)
+                {
+                    TRACE("Cannot allocate memory for DDT, continuing...");
+                    free(cmp_data);
+                    break;
+                }
+
+                read_bytes = fread(cmp_data, 1, ddt_header.cmpLength, ctx->imageStream);
+                if(read_bytes != ddt_header.cmpLength)
+                {
+                    TRACE("Could not read compressed block, continuing...");
+                    free(cmp_data);
+                    free(buffer);
+                    break;
+                }
+
+                read_bytes =
+                    aaruf_zstd_decode_buffer(buffer, ddt_header.length, cmp_data, ddt_header.cmpLength);
+
+                if(read_bytes != ddt_header.length)
+                {
+                    FATAL("Error decompressing zstd DDT, expected %zu got %zu", ddt_header.length, read_bytes);
+                    free(cmp_data);
+                    free(buffer);
+                    TRACE("Exiting process_ddt_v2() = AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK");
+                    return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+                }
+
+                free(cmp_data);
+
+                crc64_context = aaruf_crc64_init();
+
+                if(crc64_context == NULL)
+                {
+                    FATAL("Could not initialize CRC64.");
+                    free(buffer);
+                    TRACE("Exiting process_ddt_v2() = AARUF_ERROR_CANNOT_READ_BLOCK");
+                    return AARUF_ERROR_CANNOT_READ_BLOCK;
+                }
+
+                aaruf_crc64_update(crc64_context, buffer, read_bytes);
+                aaruf_crc64_final(crc64_context, &crc64);
+                aaruf_crc64_free(crc64_context);
+
+                if(crc64 != ddt_header.crc64)
+                {
+                    FATAL("Expected DDT CRC 0x%16lX but got 0x%16lX.", ddt_header.crc64, crc64);
+                    free(buffer);
+                    TRACE("Exiting process_ddt_v2() = AARUF_ERROR_INVALID_BLOCK_CRC");
+                    return AARUF_ERROR_INVALID_BLOCK_CRC;
+                }
+
+                ctx->user_data_ddt2 = (uint64_t *)buffer;
+
+                ctx->in_memory_ddt   = true;
+                *found_user_data_ddt = true;
+
+                break;
             case kCompressionNone:
                 buffer = malloc(ddt_header.length);
 
@@ -367,6 +441,83 @@ int32_t process_ddt_v2(aaruformat_context *ctx, IndexEntry *entry, bool *found_u
                 if(read_bytes != ddt_header.length)
                 {
                     FATAL("Error decompressing block, should be {0} bytes but got {1} bytes., stopping...");
+                    free(cmp_data);
+                    free(buffer);
+                    TRACE("Exiting process_ddt_v2() = AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK");
+                    return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+                }
+
+                free(cmp_data);
+                cmp_data = NULL;
+
+                crc64_context = aaruf_crc64_init();
+
+                if(crc64_context == NULL)
+                {
+                    FATAL("Could not initialize CRC64.");
+                    free(buffer);
+                    TRACE("Exiting process_ddt_v2() = AARUF_ERROR_CANNOT_READ_BLOCK");
+                    return AARUF_ERROR_CANNOT_READ_BLOCK;
+                }
+
+                aaruf_crc64_update(crc64_context, buffer, read_bytes);
+                aaruf_crc64_final(crc64_context, &crc64);
+                aaruf_crc64_free(crc64_context);
+
+                if(crc64 != ddt_header.crc64)
+                {
+                    FATAL("Expected DDT CRC 0x%16lX but got 0x%16lX.", ddt_header.crc64, crc64);
+                    free(buffer);
+                    TRACE("Exiting process_ddt_v2() = AARUF_ERROR_INVALID_BLOCK_CRC");
+                    return AARUF_ERROR_INVALID_BLOCK_CRC;
+                }
+
+                if(entry->dataType == kDataTypeCdSectorPrefix)
+                    ctx->sector_prefix_ddt2 = (uint64_t *)buffer;
+                else if(entry->dataType == kDataTypeCdSectorSuffix)
+                    ctx->sector_suffix_ddt2 = (uint64_t *)buffer;
+                else
+                    free(buffer);
+
+                break;
+            case kCompressionZstd:
+                if(ddt_header.cmpLength == 0)
+                {
+                    FATAL("Compressed DDT payload has zero length for zstd.");
+                    TRACE("Exiting process_ddt_v2() = AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK");
+                    return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+                }
+
+                cmp_data = (uint8_t *)malloc(ddt_header.cmpLength);
+                if(cmp_data == NULL)
+                {
+                    TRACE("Cannot allocate memory for DDT, continuing...");
+                    break;
+                }
+
+                buffer = malloc(ddt_header.length);
+                if(buffer == NULL)
+                {
+                    TRACE("Cannot allocate memory for DDT, continuing...");
+                    free(cmp_data);
+                    break;
+                }
+
+                read_bytes = fread(cmp_data, 1, ddt_header.cmpLength, ctx->imageStream);
+                if(read_bytes != ddt_header.cmpLength)
+                {
+                    TRACE("Could not read compressed block, continuing...");
+                    free(cmp_data);
+                    free(buffer);
+                    break;
+                }
+
+                read_bytes =
+                    aaruf_zstd_decode_buffer(buffer, ddt_header.length, cmp_data, ddt_header.cmpLength);
+
+                if(read_bytes != ddt_header.length)
+                {
+                    FATAL("Error decompressing zstd DDT, expected %zu got %zu", ddt_header.length, read_bytes);
                     free(cmp_data);
                     free(buffer);
                     TRACE("Exiting process_ddt_v2() = AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK");
@@ -900,6 +1051,85 @@ int32_t decode_ddt_multi_level_v2(aaruformat_context *ctx, uint64_t sector_addre
                 ctx->cached_ddt_offset = secondary_ddt_offset;
 
                 break;
+            case kCompressionZstd:
+                if(ddt_header.cmpLength == 0)
+                {
+                    FATAL("Compressed DDT payload has zero length for zstd.");
+                    TRACE("Exiting decode_ddt_multi_level_v2() = AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK");
+                    return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+                }
+
+                cmp_data = (uint8_t *)malloc(ddt_header.cmpLength);
+                if(cmp_data == NULL)
+                {
+                    FATAL("Cannot allocate memory for DDT, stopping...");
+                    TRACE("Exiting decode_ddt_multi_level_v2() = AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK");
+                    return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+                }
+
+                buffer = malloc(ddt_header.length);
+                if(buffer == NULL)
+                {
+                    FATAL("Cannot allocate memory for DDT, stopping...");
+                    free(cmp_data);
+                    return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+                }
+
+                read_bytes = fread(cmp_data, 1, ddt_header.cmpLength, ctx->imageStream);
+                if(read_bytes != ddt_header.cmpLength)
+                {
+                    FATAL("Could not read compressed block, stopping...");
+                    free(cmp_data);
+                    free(buffer);
+                    TRACE("Exiting decode_ddt_multi_level_v2() = AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK");
+                    return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+                }
+
+                TRACE("Decompressing block of size %zu bytes", ddt_header.length);
+                read_bytes =
+                    aaruf_zstd_decode_buffer(buffer, ddt_header.length, cmp_data, ddt_header.cmpLength);
+
+                if(read_bytes != ddt_header.length)
+                {
+                    FATAL("Error decompressing zstd DDT, expected %zu got %zu", ddt_header.length, read_bytes);
+                    free(cmp_data);
+                    free(buffer);
+                    TRACE("Exiting decode_ddt_multi_level_v2() = AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK");
+                    return AARUF_ERROR_CANNOT_DECOMPRESS_BLOCK;
+                }
+
+                free(cmp_data);
+
+                crc64_context = aaruf_crc64_init();
+
+                if(crc64_context == NULL)
+                {
+                    FATAL("Could not initialize CRC64.");
+                    free(buffer);
+                    TRACE("Exiting decode_ddt_multi_level_v2() = AARUF_ERROR_CANNOT_READ_BLOCK");
+                    return AARUF_ERROR_CANNOT_READ_BLOCK;
+                }
+
+                aaruf_crc64_update(crc64_context, buffer, read_bytes);
+                aaruf_crc64_final(crc64_context, &crc64);
+                aaruf_crc64_free(crc64_context);
+
+                if(crc64 != ddt_header.crc64)
+                {
+                    FATAL("Expected DDT CRC 0x%16lX but got 0x%16lX.", ddt_header.crc64, crc64);
+                    free(buffer);
+                    TRACE("Exiting decode_ddt_multi_level_v2() = AARUF_ERROR_INVALID_BLOCK_CRC");
+                    return AARUF_ERROR_INVALID_BLOCK_CRC;
+                }
+
+                // Free old cached DDT before replacing it
+                free(ctx->cached_secondary_ddt2);
+
+                ctx->cached_secondary_ddt2 = (uint64_t *)buffer;
+
+                ctx->cached_ddt_offset = secondary_ddt_offset;
+
+                break;
             case kCompressionNone:
                 buffer = malloc(ddt_header.length);
 
@@ -1217,8 +1447,9 @@ bool set_ddt_multi_level_v2(aaruformat_context *ctx, uint64_t sector_address, bo
             memset(&ddt_header, 0, sizeof(DdtHeader2));
             ddt_header.identifier = DeDuplicationTableSecondary;
             ddt_header.type       = kDataTypeUserData;
-            ddt_header.compression =
-                ctx->compression_enabled ? kCompressionLzma : kCompressionNone;  // Use no compression for simplicity
+            ddt_header.compression = ctx->compression_enabled
+                                         ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma)
+                                         : kCompressionNone;
             ddt_header.levels              = ctx->user_data_ddt_header.levels;
             ddt_header.tableLevel          = ctx->user_data_ddt_header.tableLevel + 1;
             ddt_header.previousLevelOffset = ctx->primary_ddt_offset;
@@ -1268,11 +1499,23 @@ bool set_ddt_multi_level_v2(aaruformat_context *ctx, uint64_t sector_address, bo
                     return AARUF_ERROR_NOT_ENOUGH_MEMORY;
                 }
 
-                size_t dst_size   = (size_t)ddt_header.length * 2 * 2;
-                size_t props_size = LZMA_PROPERTIES_LENGTH;
-                aaruf_lzma_encode_buffer(cmp_buffer, &dst_size, (uint8_t *)ctx->cached_secondary_ddt2,
-                                         ddt_header.length, lzma_properties, &props_size, 9, ctx->lzma_dict_size, 4, 0,
-                                         2, 273, LZMA_THREADS(ctx));
+                size_t dst_size;
+
+                if(ctx->use_zstd)
+                {
+                    dst_size = aaruf_zstd_encode_buffer(cmp_buffer, (size_t)ddt_header.length * 2,
+                                                         (uint8_t *)ctx->cached_secondary_ddt2, ddt_header.length,
+                                                         ctx->zstd_level, ctx->num_threads);
+                    if(dst_size == 0) dst_size = ddt_header.length;
+                }
+                else
+                {
+                    dst_size          = (size_t)ddt_header.length * 2 * 2;
+                    size_t props_size = LZMA_PROPERTIES_LENGTH;
+                    aaruf_lzma_encode_buffer(cmp_buffer, &dst_size, (uint8_t *)ctx->cached_secondary_ddt2,
+                                             ddt_header.length, lzma_properties, &props_size, 9, ctx->lzma_dict_size,
+                                             4, 0, 2, 273, LZMA_THREADS(ctx));
+                }
 
                 ddt_header.cmpLength = (uint32_t)dst_size;
 
@@ -1291,7 +1534,10 @@ bool set_ddt_multi_level_v2(aaruformat_context *ctx, uint64_t sector_address, bo
                 ddt_header.cmpCrc64  = ddt_header.crc64;
             }
             else
+            {
                 ddt_header.cmpCrc64 = aaruf_crc64_data(cmp_buffer, (uint32_t)ddt_header.cmpLength);
+                if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+            }
 
             if(ddt_header.compression == kCompressionLzma) ddt_header.cmpLength += LZMA_PROPERTIES_LENGTH;
 
@@ -1315,7 +1561,7 @@ bool set_ddt_multi_level_v2(aaruformat_context *ctx, uint64_t sector_address, bo
                 return false;
             }
 
-            if(ddt_header.compression == kCompressionLzma) free(cmp_buffer);
+            if(ddt_header.compression != kCompressionNone) free(cmp_buffer);
 
             // Add index entry for the newly written secondary DDT
             IndexEntry new_ddt_entry;
@@ -1396,7 +1642,8 @@ bool set_ddt_multi_level_v2(aaruformat_context *ctx, uint64_t sector_address, bo
         memset(&ddt_header, 0, sizeof(DdtHeader2));
         ddt_header.identifier          = DeDuplicationTableSecondary;
         ddt_header.type                = kDataTypeUserData;
-        ddt_header.compression         = ctx->compression_enabled ? kCompressionLzma : kCompressionNone;
+        ddt_header.compression =
+            ctx->compression_enabled ? (ctx->use_zstd ? kCompressionZstd : kCompressionLzma) : kCompressionNone;
         ddt_header.levels              = ctx->user_data_ddt_header.levels;
         ddt_header.tableLevel          = ctx->user_data_ddt_header.tableLevel + 1;
         ddt_header.previousLevelOffset = ctx->primary_ddt_offset;  // Set to primary DDT table location
@@ -1446,10 +1693,23 @@ bool set_ddt_multi_level_v2(aaruformat_context *ctx, uint64_t sector_address, bo
                 return AARUF_ERROR_NOT_ENOUGH_MEMORY;
             }
 
-            size_t dst_size   = (size_t)ddt_header.length * 2 * 2;
-            size_t props_size = LZMA_PROPERTIES_LENGTH;
-            aaruf_lzma_encode_buffer(cmp_buffer, &dst_size, (uint8_t *)ctx->cached_secondary_ddt2, ddt_header.length,
-                                     lzma_properties, &props_size, 9, ctx->lzma_dict_size, 4, 0, 2, 273, LZMA_THREADS(ctx));
+            size_t dst_size;
+
+            if(ctx->use_zstd)
+            {
+                dst_size = aaruf_zstd_encode_buffer(cmp_buffer, (size_t)ddt_header.length * 2,
+                                                     (uint8_t *)ctx->cached_secondary_ddt2, ddt_header.length,
+                                                     ctx->zstd_level, ctx->num_threads);
+                if(dst_size == 0) dst_size = ddt_header.length;
+            }
+            else
+            {
+                dst_size          = (size_t)ddt_header.length * 2 * 2;
+                size_t props_size = LZMA_PROPERTIES_LENGTH;
+                aaruf_lzma_encode_buffer(cmp_buffer, &dst_size, (uint8_t *)ctx->cached_secondary_ddt2,
+                                         ddt_header.length, lzma_properties, &props_size, 9, ctx->lzma_dict_size, 4, 0,
+                                         2, 273, LZMA_THREADS(ctx));
+            }
 
             ddt_header.cmpLength = (uint32_t)dst_size;
 
@@ -1468,7 +1728,10 @@ bool set_ddt_multi_level_v2(aaruformat_context *ctx, uint64_t sector_address, bo
             ddt_header.cmpCrc64  = ddt_header.crc64;
         }
         else
+        {
             ddt_header.cmpCrc64 = aaruf_crc64_data(cmp_buffer, (uint32_t)ddt_header.cmpLength);
+            if(ctx->use_zstd) ctx->has_zstd_blocks = true;
+        }
 
         if(ddt_header.compression == kCompressionLzma) ddt_header.cmpLength += LZMA_PROPERTIES_LENGTH;
 
@@ -1494,7 +1757,7 @@ bool set_ddt_multi_level_v2(aaruformat_context *ctx, uint64_t sector_address, bo
             return false;
         }
 
-        if(ddt_header.compression == kCompressionLzma) free(cmp_buffer);
+        if(ddt_header.compression != kCompressionNone) free(cmp_buffer);
 
         // Update index: remove old entry and add new one for the evicted secondary DDT
         TRACE("Updating index for evicted secondary DDT");

--- a/src/write.c
+++ b/src/write.c
@@ -1621,6 +1621,8 @@ int32_t aaruf_close_current_block(aaruformat_context *ctx)
                     free(cmp_buffer);
                     cmp_buffer = NULL;
                 }
+                else
+                    ctx->has_zstd_blocks = true;
             }
 
             break;


### PR DESCRIPTION
The initial zstd implementation (PRs #9, #15, #17) only applied zstd to data blocks and subchannel blocks. All other compressed sections in `close.c` remained hardcoded to LZMA. This PR completes zstd coverage across the entire format.

## Changes

### Writer (`close.c`, `ddt/ddt_v2.c`)

All remaining compressed sections now respect `ctx->use_zstd`:

- DDT (secondary, single-level, tape, multi-level eviction paths)
- Mode 2 subheaders
- CD sector prefix / suffix
- Sector prefix / suffix DDT v2
- DVD sector ID / IED / CPR_MAI / EDC
- DVD decrypted title key
- Media tags
- Flux capture payload

### Reader (`ddt/ddt_v1.c`, `ddt/ddt_v2.c`, `blocks/flux.c`)

Added `case kCompressionZstd:` to all DDT decompression switch statements (5 locations) and a `read_zstd_compressed_payload()` function for flux data. The data block reader (`read.c`) and block processor (`blocks/data.c`) already handled zstd and required no changes.

### Feature bit (`enums.h`, `consts.h`, `context.h`, `close.c`)

Defines `AARU_FEATURE_INCOMPAT_ZSTD = 0x1` in a new `FeaturesIncompatible` enum. The bit is set in the V2 header only when a zstd-compressed block is actually retained in the output (tracked via `ctx->has_zstd_blocks`). If all compression attempts fall back to `kCompressionNone`, the bit is not set.

`AARUF_KNOWN_INCOMPAT_FEATURES` is updated so our reader accepts the bit. Old readers that do not define it will reject zstd images at open time via the existing check in `open.c`.

The feature mask macros in `consts.h` now use literal values (`0x1ULL`) instead of enum casts, so the header compiles standalone without depending on `enums.h` include order.

### Pattern

Each section follows the same transformation, modeled on the existing subchannel block pattern:

1. Compression type selection: `ctx->use_zstd ? kCompressionZstd : kCompressionLzma`
2. Conditional encode: zstd branch calls `aaruf_zstd_encode_buffer`, else LZMA as before
3. LZMA property guards unchanged (correctly exclude zstd)
4. Buffer free guard: `!= kCompressionNone` (covers both zstd and LZMA)
5. Feature tracking: `ctx->has_zstd_blocks = true` set when compression survives the size check

Closes #26.