### PR TITLE
build: add aaruformatread CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,9 @@ else()
   message(STATUS "Building static library")
 endif()
 
-add_library(aaruformat
+# Sources shared between full (aaruformat) and reader-only (aaruformatread) targets.
+# Writer-only functions in some of these files are guarded by #ifndef AARUFORMAT_READER_ONLY.
+set(AARUFORMAT_COMMON_SOURCES
             include/aaruformat/consts.h
             include/aaruformat/enums.h
             include/aaru.h
@@ -196,7 +198,6 @@ add_library(aaruformat
             src/open.c
             include/aaruformat/context.h
             src/close.c
-            src/close_write.c
             include/aaruformat/errors.h
             src/read.c
             include/aaruformat/crc64.h
@@ -240,9 +241,7 @@ add_library(aaruformat
             src/ddt/ddt_v2.c
             include/aaruformat/structs/options.h
             src/options.c
-            src/create.c
             src/time.c
-            src/write.c
             include/log.h
             src/ddt/hash_map.c
             include/aaruformat/hash_map.h
@@ -257,7 +256,6 @@ add_library(aaruformat
             src/lisa_tag.c
             include/aaruformat/structs/lisa_tag.h
             src/metadata.c
-            src/metadata_write.c
             src/dump.c
             include/aaruformat/structs/tape.h
             src/blocks/tape.c
@@ -278,15 +276,33 @@ add_library(aaruformat
             src/ngcw/wii_crypto.h
             src/compression/zstd.c)
 
-# Set up include directories for the target
-target_include_directories(aaruformat
-                           PUBLIC
-                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/aaruformat>
-                           $<INSTALL_INTERFACE:include>
-                           ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/uthash/include
-                           ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/uthash/src
-)
+# Writer-only sources — excluded from the reader-only target.
+set(AARUFORMAT_WRITER_SOURCES
+            src/create.c
+            src/write.c
+            src/close_write.c
+            src/metadata_write.c)
+
+# Full library (LGPL 2.1) — read + write
+add_library(aaruformat ${AARUFORMAT_COMMON_SOURCES} ${AARUFORMAT_WRITER_SOURCES})
+
+# Reader-only library (MIT) — read, identify, open, verify, get-metadata
+add_library(aaruformatread ${AARUFORMAT_COMMON_SOURCES})
+target_compile_definitions(aaruformatread PRIVATE AARUFORMAT_READER_ONLY)
+
+# Both targets share the same include directories, dependencies, and flags.
+set(AARUFORMAT_TARGETS aaruformat aaruformatread)
+
+foreach(_target ${AARUFORMAT_TARGETS})
+  target_include_directories(${_target}
+                             PUBLIC
+                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/aaruformat>
+                             $<INSTALL_INTERFACE:include>
+                             ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/uthash/include
+                             ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/uthash/src
+  )
+endforeach()
 
 # Load third-party dependencies
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake-modules")
@@ -297,9 +313,11 @@ include(3rdparty/xxhash.cmake)
 include(3rdparty/blake3.cmake)
 include(3rdparty/zstd.cmake)
 
-if(TARGET blake3)
-  target_link_libraries(aaruformat blake3)
-endif()
+foreach(_target ${AARUFORMAT_TARGETS})
+  if(TARGET blake3)
+    target_link_libraries(${_target} blake3)
+  endif()
+endforeach()
 
 macro(TARGET_LINK_LIBRARIES_WHOLE_ARCHIVE target)
   if(MSVC)
@@ -318,13 +336,15 @@ macro(TARGET_LINK_LIBRARIES_WHOLE_ARCHIVE target)
 endmacro()
 
 # MinGW/ARM specific: disable PIC
-if(NOT "${CMAKE_C_PLATFORM_ID}" MATCHES "MinGW"
-   OR (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm"
-   AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64"))
-  set_property(TARGET aaruformat PROPERTY POSITION_INDEPENDENT_CODE TRUE)
-else()
-  set_property(TARGET aaruformat PROPERTY POSITION_INDEPENDENT_CODE FALSE)
-endif()
+foreach(_target ${AARUFORMAT_TARGETS})
+  if(NOT "${CMAKE_C_PLATFORM_ID}" MATCHES "MinGW"
+     OR (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm"
+     AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64"))
+    set_property(TARGET ${_target} PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+  else()
+    set_property(TARGET ${_target} PROPERTY POSITION_INDEPENDENT_CODE FALSE)
+  endif()
+endforeach()
 
 # Add slog submodule
 if(POLICY CMP0000)
@@ -335,14 +355,11 @@ endif()
 if(USE_SLOG)
   add_subdirectory(3rdparty/slog)
 
-  # Include slog headers
-  target_include_directories(aaruformat PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/slog/src)
-
-  # Enable TRACE and slog output
-  target_compile_definitions(aaruformat PRIVATE ENABLE_TRACE ENABLE_FATAL USE_SLOG)
-
-  # Link slog
-  target_link_libraries(aaruformat slog)
+  foreach(_target ${AARUFORMAT_TARGETS})
+    target_include_directories(${_target} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/slog/src)
+    target_compile_definitions(${_target} PRIVATE ENABLE_TRACE ENABLE_FATAL USE_SLOG)
+    target_link_libraries(${_target} slog)
+  endforeach()
 
   message(STATUS "slog logging enabled")
 else()
@@ -354,7 +371,9 @@ include(CheckLibraryExists)
 
 check_library_exists(m cos "" HAVE_LIB_M)
 if(HAVE_LIB_M)
-  target_link_libraries(aaruformat m)
+  foreach(_target ${AARUFORMAT_TARGETS})
+    target_link_libraries(${_target} m)
+  endforeach()
 endif()
 
 # Find Doxygen for documentation generation

--- a/src/blocks/flux.c
+++ b/src/blocks/flux.c
@@ -549,6 +549,8 @@ AARU_EXPORT int32_t AARU_CALL aaruf_get_flux_captures(void *context, uint8_t *bu
     return AARUF_STATUS_OK;
 }
 
+#ifndef AARUFORMAT_READER_ONLY
+
 /**
  * @brief Add a flux capture to the image during write mode.
  *
@@ -806,6 +808,8 @@ AARU_EXPORT int32_t AARU_CALL aaruf_clear_flux_captures(void *context)
     TRACE("Exiting aaruf_clear_flux_captures() = AARUF_STATUS_OK");
     return AARUF_STATUS_OK;
 }
+
+#endif  // !AARUFORMAT_READER_ONLY
 
 /**
  * @brief Find a flux entry by its identifier key.

--- a/src/blocks/optical.c
+++ b/src/blocks/optical.c
@@ -328,6 +328,8 @@ AARU_EXPORT int32_t AARU_CALL aaruf_get_tracks(const void *context, uint8_t *buf
     return AARUF_STATUS_OK;
 }
 
+#ifndef AARUFORMAT_READER_ONLY
+
 /**
  * @brief Replace (or clear) the in-memory track table for an AaruFormat image context.
  *
@@ -489,3 +491,5 @@ AARU_EXPORT int32_t AARU_CALL aaruf_set_tracks(void *context, TrackEntry *tracks
     TRACE("Exiting aaruf_set_tracks() = AARUF_STATUS_OK");
     return AARUF_STATUS_OK;
 }
+
+#endif  // !AARUFORMAT_READER_ONLY

--- a/src/blocks/tape.c
+++ b/src/blocks/tape.c
@@ -613,6 +613,8 @@ AARU_EXPORT int32_t AARU_CALL aaruf_get_tape_file(const void *context, const uin
     return AARUF_STATUS_OK;
 }
 
+#ifndef AARUFORMAT_READER_ONLY
+
 /**
  * @brief Sets or updates the block range for a specific tape file in an Aaru tape image.
  *
@@ -843,6 +845,8 @@ AARU_EXPORT int32_t AARU_CALL aaruf_set_tape_file(void *context, const uint8_t p
     return AARUF_STATUS_OK;
 }
 
+#endif  // !AARUFORMAT_READER_ONLY
+
 /**
  * @brief Retrieves the block range for a specific tape partition from an Aaru tape image.
  *
@@ -1025,6 +1029,8 @@ AARU_EXPORT int32_t AARU_CALL aaruf_get_tape_partition(const void *context, cons
           *ending_block);
     return AARUF_STATUS_OK;
 }
+
+#ifndef AARUFORMAT_READER_ONLY
 
 /**
  * @brief Sets or updates the block range for a specific tape partition in an Aaru tape image.
@@ -1267,6 +1273,8 @@ AARU_EXPORT int32_t AARU_CALL aaruf_set_tape_partition(void *context, const uint
           ending_block);
     return AARUF_STATUS_OK;
 }
+
+#endif  // !AARUFORMAT_READER_ONLY
 
 /**
  * @brief Retrieves all tape file entries from the image.

--- a/src/ddt/ddt_v2.c
+++ b/src/ddt/ddt_v2.c
@@ -1213,6 +1213,8 @@ int32_t decode_ddt_multi_level_v2(aaruformat_context *ctx, uint64_t sector_addre
     return AARUF_STATUS_OK;
 }
 
+#ifndef AARUFORMAT_READER_ONLY
+
 /**
  * @brief Sets a DDT v2 entry for a given sector address.
  *
@@ -2124,3 +2126,5 @@ bool set_ddt_tape(aaruformat_context *ctx, uint64_t sector_address, const uint64
     TRACE("Exiting set_ddt_tape() = true");
     return true;
 }
+
+#endif  // !AARUFORMAT_READER_ONLY

--- a/src/dump.c
+++ b/src/dump.c
@@ -368,6 +368,8 @@ AARU_EXPORT int32_t AARU_CALL aaruf_get_dumphw(void *context, uint8_t *buffer, s
     return AARUF_STATUS_OK;
 }
 
+#ifndef AARUFORMAT_READER_ONLY
+
 /**
  * @brief Sets the dump hardware block for the image during creation.
  *
@@ -697,3 +699,5 @@ free_copy_and_error:
     TRACE("Exiting aaruf_set_dumphw() = AARUF_ERROR_NOT_ENOUGH_MEMORY");
     return AARUF_ERROR_NOT_ENOUGH_MEMORY;
 }
+
+#endif  // !AARUFORMAT_READER_ONLY

--- a/src/open.c
+++ b/src/open.c
@@ -677,6 +677,13 @@ AARU_EXPORT void *AARU_CALL aaruf_open(const char *filepath, const bool resume_m
         return ctx;
     }
 
+#ifdef AARUFORMAT_READER_ONLY
+    // Reader-only builds do not support resume mode
+    FATAL("Resume mode not available in reader-only library");
+    errno = AARUF_ERROR_INCOMPATIBLE_VERSION;
+    cleanup_open_failure(ctx);
+    return NULL;
+#else
     // Parse the options
     TRACE("Parsing options");
     bool               table_shift_found = false;
@@ -720,4 +727,5 @@ AARU_EXPORT void *AARU_CALL aaruf_open(const char *filepath, const bool resume_m
     TRACE("Exiting aaruf_open() = %p", ctx);
     // Return context
     return ctx;
+#endif  // !AARUFORMAT_READER_ONLY
 }


### PR DESCRIPTION
Add a read-only library target (aaruformatread) alongside the existing full read/write target (aaruformat). The reader target excludes four writer-only source files: create.c, write.c, close_write.c, and metadata_write.c.

Writer functions in shared source files are guarded with #ifndef AARUFORMAT_READER_ONLY so the reader target exports zero writer symbols:
- open.c: resume-mode block (sets finalize_write, calls create_map)
- ddt/ddt_v2.c: set_ddt_* functions (call aaruf_close_current_block)
- dump.c: aaruf_set_dumphw
- blocks/optical.c: aaruf_set_tracks
- blocks/tape.c: aaruf_set_tape_file, aaruf_set_tape_partition
- blocks/flux.c: aaruf_write_flux_capture, aaruf_clear_flux_captures

CMakeLists.txt refactored to use AARUFORMAT_COMMON_SOURCES and AARUFORMAT_WRITER_SOURCES variables. Both targets share the same include directories, third-party dependencies, and compiler flags via a foreach loop over AARUFORMAT_TARGETS.

Verified:
- Both targets build cleanly (shared libraries)
- nm -D libaaruformatread.so shows zero set_/clear_/write_/create symbols
- Reader library is ~1 MB vs ~5 MB for the full library