### PR TITLE
Fixes to make it compile with `-Werror=strict-prototype`

### DIFF
--- a/include/aaru.h
+++ b/include/aaru.h
@@ -19,7 +19,7 @@
 #ifndef LIBAARUFORMAT_AARU_H
 #define LIBAARUFORMAT_AARU_H
 
-#ifndef _MSC_VER
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "OCUnusedGlobalDeclarationInspection"
 #endif
@@ -1094,7 +1094,7 @@ typedef enum
 
 // NOLINTEND(readability-identifier-naming)
 
-#ifndef _MSC_VER
+#ifdef __clang__
 #pragma clang diagnostic pop
 #endif
 

--- a/include/aaruformat/consts.h
+++ b/include/aaruformat/consts.h
@@ -19,7 +19,7 @@
 #ifndef LIBAARUFORMAT_CONSTS_H
 #define LIBAARUFORMAT_CONSTS_H
 
-#ifndef _MSC_VER
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "OCUnusedMacroInspection"
 #endif
@@ -114,7 +114,7 @@
 /** Magic number at the end of the recovery footer: "AVRECMFR" in ASCII little-endian. */
 #define AARU_RECOVERY_FOOTER_MAGIC 0x52464D4345525641ULL
 
-#ifndef _MSC_VER
+#ifdef __clang__
 #pragma clang diagnostic pop
 #endif
 

--- a/include/aaruformat/decls.h
+++ b/include/aaruformat/decls.h
@@ -80,7 +80,7 @@ AARU_EXPORT int AARU_CALL aaruf_close(void *context);
 
 AARU_EXPORT int32_t AARU_CALL aaruf_read_media_tag(void *context, uint8_t *data, int32_t tag, uint32_t *length);
 
-AARU_EXPORT crc64_ctx *AARU_CALL aaruf_crc64_init();
+AARU_EXPORT crc64_ctx *AARU_CALL aaruf_crc64_init(void);
 AARU_EXPORT int AARU_CALL        aaruf_crc64_update(crc64_ctx *ctx, const uint8_t *data, uint32_t len);
 AARU_EXPORT int AARU_CALL        aaruf_crc64_final(crc64_ctx *ctx, uint64_t *crc);
 AARU_EXPORT void AARU_CALL       aaruf_crc64_free(crc64_ctx *ctx);
@@ -120,7 +120,7 @@ AARU_EXPORT int32_t AARU_CALL aaruf_cst_transform(const uint8_t *interleaved, ui
 
 AARU_EXPORT int32_t AARU_CALL aaruf_cst_untransform(const uint8_t *sequential, uint8_t *interleaved, size_t length);
 
-AARU_EXPORT void *AARU_CALL aaruf_ecc_cd_init();
+AARU_EXPORT void *AARU_CALL aaruf_ecc_cd_init(void);
 
 AARU_EXPORT void AARU_CALL aaruf_ecc_cd_free(void *context);
 
@@ -277,17 +277,17 @@ AARU_EXPORT void AARU_CALL aaruf_sha256_buffer(const void *data, unsigned long s
 #if defined(__x86_64__) || defined(__amd64) || defined(_M_AMD64) || defined(_M_X64) || defined(__I386__) || \
     defined(__i386__) || defined(__THW_INTEL) || defined(_M_IX86)
 
-AARU_EXPORT int have_clmul();
-AARU_EXPORT int have_ssse3();
-AARU_EXPORT int have_avx2();
+AARU_EXPORT int have_clmul(void);
+AARU_EXPORT int have_ssse3(void);
+AARU_EXPORT int have_avx2(void);
 
 AARU_EXPORT CLMUL uint64_t AARU_CALL aaruf_crc64_clmul(uint64_t crc, const uint8_t *data, long length);
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
-AARU_EXPORT int have_neon();
-AARU_EXPORT int have_arm_crc32();
-AARU_EXPORT int have_arm_crypto();
+AARU_EXPORT int have_neon(void);
+AARU_EXPORT int have_arm_crc32(void);
+AARU_EXPORT int have_arm_crypto(void);
 
 AARU_EXPORT TARGET_WITH_SIMD uint64_t AARU_CALL aaruf_crc64_vmull(uint64_t previous_crc, const uint8_t *data, long len);
 #endif

--- a/include/aaruformat/enums.h
+++ b/include/aaruformat/enums.h
@@ -19,7 +19,7 @@
 #ifndef LIBAARUFORMAT_ENUMS_H
 #define LIBAARUFORMAT_ENUMS_H
 
-#ifndef _MSC_VER
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "OCUnusedGlobalDeclarationInspection"
 #endif
@@ -342,7 +342,7 @@ typedef enum
     kECGroupIndex       = 4   ///< Index block (K=1, M replicas).
 } ErasureCodingGroupType;
 
-#ifndef _MSC_VER
+#ifdef __clang__
 #pragma clang diagnostic pop
 #endif
 

--- a/include/aaruformat/structs.h
+++ b/include/aaruformat/structs.h
@@ -16,7 +16,7 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _MSC_VER
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "OCUnusedGlobalDeclarationInspection"
 #endif
@@ -44,6 +44,6 @@
 
 #endif  // LIBAARUFORMAT_STRUCTS_H
 
-#ifndef _MSC_VER
+#ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/src/checksum/ecc_cd.c
+++ b/src/checksum/ecc_cd.c
@@ -32,7 +32,7 @@
  *
  * @return Pointer to the initialized CdEccContext structure, or NULL on failure.
  */
-AARU_EXPORT void *AARU_CALL aaruf_ecc_cd_init()
+AARU_EXPORT void *AARU_CALL aaruf_ecc_cd_init(void)
 {
     TRACE("Entering aaruf_ecc_cd_init()");
     CdEccContext *context = NULL;

--- a/src/checksum/simd.c
+++ b/src/checksum/simd.c
@@ -116,7 +116,7 @@ static void cpuidex(int info, int count, unsigned *eax, unsigned *ebx, unsigned 
  *
  * @return Non-zero if supported, zero otherwise.
  */
-int have_clmul()
+int have_clmul(void)
 {
     TRACE("Entering have_clmul()");
 
@@ -135,7 +135,7 @@ int have_clmul()
  *
  * @return Non-zero if supported, zero otherwise.
  */
-int have_ssse3()
+int have_ssse3(void)
 {
     TRACE("Entering have_ssse3()");
     unsigned eax, ebx, ecx, edx;
@@ -150,7 +150,7 @@ int have_ssse3()
  *
  * @return Non-zero if supported, zero otherwise.
  */
-int have_avx2()
+int have_avx2(void)
 {
     TRACE("Entering have_avx2()");
     unsigned eax, ebx, ecx, edx;
@@ -179,7 +179,7 @@ int have_avx2()
  *
  * @return Non-zero if supported, zero otherwise.
  */
-int have_neon_apple()
+int have_neon_apple(void)
 {
     TRACE("Entering have_neon_apple()");
     int    value = 0;
@@ -201,7 +201,7 @@ int have_neon_apple()
  *
  * @return Non-zero if supported, zero otherwise.
  */
-int have_crc32_apple()
+int have_crc32_apple(void)
 {
     TRACE("Entering have_crc32_apple()");
     int    value = 0;
@@ -223,16 +223,16 @@ int have_crc32_apple()
  *
  * @return Non-zero if supported, zero otherwise.
  */
-int have_crypto_apple() { return 0; }
+int have_crypto_apple(void) { return 0; }
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
-int have_neon()
+int have_neon(void)
 {
     return 1;  // ARMv8-A made it mandatory
 }
 
-int have_arm_crc32()
+int have_arm_crc32(void)
 {
 #if defined(_WIN32)
     return IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE) != 0;
@@ -243,7 +243,7 @@ int have_arm_crc32()
 #endif
 }
 
-int have_arm_crypto()
+int have_arm_crypto(void)
 {
 #if defined(_WIN32)
     return IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0;
@@ -256,7 +256,7 @@ int have_arm_crypto()
 #endif
 
 #if defined(__arm__) || defined(_M_ARM)
-int have_neon()
+int have_neon(void)
 {
 #if defined(_WIN32)
     return IsProcessorFeaturePresent(PF_ARM_VFP_32_REGISTERS_AVAILABLE) != 0;
@@ -267,7 +267,7 @@ int have_neon()
 #endif
 }
 
-int have_arm_crc32()
+int have_arm_crc32(void)
 {
 #if defined(_WIN32)
     return IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE) != 0;
@@ -278,7 +278,7 @@ int have_arm_crc32()
 #endif
 }
 
-int have_arm_crypto()
+int have_arm_crypto(void)
 {
 #if defined(_WIN32)
     return IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0;


### PR DESCRIPTION
Some fixes to make it compile with `-Werror=strict-prototypes` enabled.

Also ensures that some IDE warnings get ignored only on Clang.