### PR TITLE
Add missing PS5BD/UHDBD to OpticalDisc

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -445,6 +445,7 @@ AARU_LOCAL int32_t AARU_CALL aaruf_get_xml_mediatype(const int32_t type)
         case BDRE:
         case BDRXL:
         case BDREXL:
+        case UHDBD:
         case EVD:
         case FVD:
         case HVD:
@@ -464,6 +465,7 @@ AARU_LOCAL int32_t AARU_CALL aaruf_get_xml_mediatype(const int32_t type)
         case PS3DVD:
         case PS3BD:
         case PS4BD:
+        case PS5BD:
         case UMD:
         case XGD:
         case XGD2:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New filesystem, test images in [url]
- [ ] New media image, test images in [url]
- [ ] New partition scheme, test images in [url]
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Add missing media types PS5BD and UHDBD to aaruf_get_xml_mediatype for optical discs.

Maybe the "xml" function should replaced by some generic meaning (e.g. aaruf_get_metadata_mediatype) in future, since export is in .json file.