### PR TITLE
fix: correct readableSectorTags allocation size to prevent heap overflow

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -361,7 +361,7 @@ AARU_EXPORT void *AARU_CALL aaruf_create(const char *filepath, const uint32_t me
     TRACE("Generating random GUID");
     generate_random_bytes(ctx->header.guid, GUID_SIZE);
 
-    ctx->readableSectorTags = (bool *)malloc(sizeof(bool) * MaxSectorTag);
+    ctx->readableSectorTags = (bool *)malloc(sizeof(bool) * (MaxSectorTag + 1));
 
     if(ctx->readableSectorTags == NULL)
     {
@@ -371,7 +371,7 @@ AARU_EXPORT void *AARU_CALL aaruf_create(const char *filepath, const uint32_t me
         return NULL;
     }
 
-    memset(ctx->readableSectorTags, 0, sizeof(bool) * MaxSectorTag);
+    memset(ctx->readableSectorTags, 0, sizeof(bool) * (MaxSectorTag + 1));
 
     // Initialize image info
     TRACE("Initializing image info");

--- a/src/open.c
+++ b/src/open.c
@@ -430,7 +430,7 @@ AARU_EXPORT void *AARU_CALL aaruf_open(const char *filepath, const bool resume_m
     TRACE("Opening image version %d.%d", ctx->header.imageMajorVersion, ctx->header.imageMinorVersion);
 
     TRACE("Allocating memory for readable sector tags bitmap");
-    ctx->readableSectorTags = (bool *)malloc(sizeof(bool) * MaxSectorTag);
+    ctx->readableSectorTags = (bool *)malloc(sizeof(bool) * (MaxSectorTag + 1));
 
     if(ctx->readableSectorTags == NULL)
     {
@@ -442,7 +442,7 @@ AARU_EXPORT void *AARU_CALL aaruf_open(const char *filepath, const bool resume_m
         return NULL;
     }
 
-    memset(ctx->readableSectorTags, 0, sizeof(bool) * MaxSectorTag);
+    memset(ctx->readableSectorTags, 0, sizeof(bool) * (MaxSectorTag + 1));
 
     TRACE("Setting up image info");
 


### PR DESCRIPTION
The readableSectorTags array was one element too small (MaxSectorTag instead of MaxSectorTag + 1), causing a heap overflow when the highest tag index was written.